### PR TITLE
Build Linux using depends system, prevent segfault

### DIFF
--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -43,7 +43,7 @@ RUN cd /DAPS/ && mkdir -p /BUILD/ && \
         su && \
         apt-get remove libzmq3-dev -y && \
         ./autogen.sh && \
-        ./configure && \
+        CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --prefix=/ && \
         make -j2 && \
         strip src/dapscoind && \
         strip src/dapscoin-cli && \

--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -43,7 +43,7 @@ RUN cd /DAPS/ && mkdir -p /BUILD/ && \
         su && \
         apt-get remove libzmq3-dev -y && \
         ./autogen.sh && \
-        CONFIG_SITE=$PWD/depends/x86_64-pc-linux-gnu/share/config.site ./configure --prefix=/ && \
+        CONFIG_SITE=$PWD/depends/x86_64-linux-gnu/share/config.site ./configure --prefix=/ && \
         make -j2 && \
         strip src/dapscoind && \
         strip src/dapscoin-cli && \

--- a/boot/cf/deps.Dockerfile
+++ b/boot/cf/deps.Dockerfile
@@ -41,8 +41,8 @@ RUN su && cd /DAPS/depends &&  \
 #
     elif [ "$BUILD_TARGET" = "linux" ]; \
       then echo "Building dependencies for linux..." && \
-        make HOST=x86_64-pc-linux-gnu -j2 && \
-        echo -e "Linux (x86_64-pc-linux-gnu) Dependencies Build complete."; \
+        make HOST=x86_64-linux-gnu -j2 && \
+        echo -e "Linux (x86_64-linux-gnu) Dependencies Build complete."; \
 #
     elif [ "$BUILD_TARGET" = "mac" ]; \
       then echo "Building dependencies for mac cross-compile..." && \


### PR DESCRIPTION
Build Linux using depends system prevent segfault
(dependencies are already built in cfprp.yml -> deps.Dockerfile)

Codefresh based on develop: https://g.codefresh.io/build/5ce49c69db1a96a7a4c4cdae ✅ 
Codefresh based on public-beta: https://g.codefresh.io/build/5ce49c87db1a96be38c4cdb5✅ 
... ran out of space on the save bin ->, https://g.codefresh.io/build/5ce4a60595b1e04cbc3d4d86 ✅ 