### PR TITLE
Depends/Update zeromq to 4.3.1

### DIFF
--- a/depends/Makefile
+++ b/depends/Makefile
@@ -5,6 +5,7 @@ BASE_CACHE ?= $(BASEDIR)/built
 SDK_PATH ?= $(BASEDIR)/SDKs
 NO_QT ?=
 NO_WALLET ?=
+NO_ZMQ ?=
 NO_UPNP ?=
 FALLBACK_DOWNLOAD_PATH ?= https://bitcoincore.org/depends-sources
 
@@ -92,12 +93,17 @@ $(host_arch)_$(host_os)_id_string+=$(shell $(host_STRIP) --version 2>/dev/null)
 qt_packages_$(NO_QT) = $(qt_packages) $(qt_$(host_os)_packages) $(qt_$(host_arch)_$(host_os)_packages)
 wallet_packages_$(NO_WALLET) = $(wallet_packages)
 upnp_packages_$(NO_UPNP) = $(upnp_packages)
+zmq_packages_$(NO_ZMQ) = $(zmq_packages)
 
 packages += $($(host_arch)_$(host_os)_packages) $($(host_os)_packages) $(qt_packages_) $(wallet_packages_) $(upnp_packages_)
 native_packages += $($(host_arch)_$(host_os)_native_packages) $($(host_os)_native_packages)
 
 ifneq ($(qt_packages_),)
 native_packages += $(qt_native_packages)
+endif
+
+ifneq ($(zmq_packages_),)
+packages += $(zmq_packages)
 endif
 
 all_packages = $(packages) $(native_packages)
@@ -136,6 +142,7 @@ $(host_prefix)/share/config.site : config.site.in $(host_prefix)/.stamp_$(final_
             -e 's|@LDFLAGS@|$(strip $(host_LDFLAGS) $(host_$(release_type)_LDFLAGS))|' \
             -e 's|@allow_host_packages@|$(ALLOW_HOST_PACKAGES)|' \
             -e 's|@no_qt@|$(NO_QT)|' \
+            -e 's|@no_zmq@|$(NO_ZMQ)|' \
             -e 's|@no_wallet@|$(NO_WALLET)|' \
             -e 's|@no_upnp@|$(NO_UPNP)|' \
             -e 's|@debug@|$(DEBUG)|' \

--- a/depends/README.md
+++ b/depends/README.md
@@ -52,6 +52,7 @@ The following can be set when running make: make FOO=bar
     SDK_PATH: Path where sdk's can be found (used by OSX)
     FALLBACK_DOWNLOAD_PATH: If a source file can't be fetched, try here before giving up
     NO_QT: Don't download/build/cache qt and its dependencies
+    NO_ZMQ: Don't download/build/cache packages needed for enabling zeromq
     NO_WALLET: Don't download/build/cache libs needed to enable the wallet
     NO_UPNP: Don't download/build/cache packages needed for enabling upnp
     DEBUG: disable some optimizations and enable more runtime checking

--- a/depends/config.site.in
+++ b/depends/config.site.in
@@ -33,6 +33,10 @@ if test -z $with_gui && test -n "@no_qt@"; then
   with_gui=no
 fi
 
+if test -z $enable_zmq && test -n "@no_zmq@"; then
+  enable_zmq=no
+fi
+
 if test x@host_os@ = xdarwin; then
   BREW=no
   PORT=no

--- a/depends/packages/packages.mk
+++ b/depends/packages/packages.mk
@@ -1,4 +1,4 @@
-packages:=boost openssl libevent zeromq
+packages:=boost openssl libevent
 native_packages := native_ccache
 
 qt_native_packages = native_protobuf
@@ -13,6 +13,8 @@ qt_darwin_packages=qt
 qt_mingw32_packages=qt
 
 wallet_packages=bdb
+
+zmq_packages=zeromq
 
 upnp_packages=miniupnpc
 

--- a/depends/packages/zeromq.mk
+++ b/depends/packages/zeromq.mk
@@ -1,9 +1,9 @@
 package=zeromq
-$(package)_version=4.2.2
+$(package)_version=4.3.1
 $(package)_download_path=https://github.com/zeromq/libzmq/releases/download/v$($(package)_version)/
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=5b23f4ca9ef545d5bd3af55d305765e3ee06b986263b31967435d285a3e6df6b
-$(package)_patches=0001-fix-build-with-older-mingw64.patch
+$(package)_sha256_hash=bcbabe1e2c7d0eec4ed612e10b94b112dd5f06fcefa994a0c79a45d835cd21eb
+$(package)_patches=0001-fix-build-with-older-mingw64.patch 0002-disable-pthread_set_name_np.patch
 
 define $(package)_set_vars
   $(package)_config_opts=--without-docs --disable-shared --without-libsodium --disable-curve --disable-curve-keygen --disable-perf

--- a/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
+++ b/depends/patches/zeromq/0002-disable-pthread_set_name_np.patch
@@ -1,0 +1,35 @@
+From c9bbdd6581d07acfe8971e4bcebe278a3676cf03 Mon Sep 17 00:00:00 2001
+From: mruddy <6440430+mruddy@users.noreply.github.com>
+Date: Sat, 30 Jun 2018 09:57:18 -0400
+Subject: [PATCH] disable pthread_set_name_np
+
+pthread_set_name_np adds a Glibc requirement on >= 2.12.
+---
+ src/thread.cpp | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/src/thread.cpp b/src/thread.cpp
+index a1086b0c..9943f354 100644
+--- a/src/thread.cpp
++++ b/src/thread.cpp
+@@ -307,7 +307,7 @@ void zmq::thread_t::setThreadName (const char *name_)
+  */
+     if (!name_)
+         return;
+-
++#if 0
+ #if defined(ZMQ_HAVE_PTHREAD_SETNAME_1)
+     int rc = pthread_setname_np (name_);
+     if (rc)
+@@ -323,6 +323,8 @@ void zmq::thread_t::setThreadName (const char *name_)
+ #elif defined(ZMQ_HAVE_PTHREAD_SET_NAME)
+     pthread_set_name_np (descriptor, name_);
+ #endif
++#endif
++    return;
+ }
+ 
+ #endif
+-- 
+2.17.1
+


### PR DESCRIPTION
Addresses https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6250

https://github.com/zeromq/libzmq/releases/tag/v4.3.1

"CVE-2019-6250: A vulnerability has been found that would allow attackers to direct a peer to
jump to and execute from an address indicated by the attacker.
This issue has been present since v4.2.0. Older releases are not affected.
NOTE: The attacker needs to know in advance valid addresses in the peer's
memory to jump to, so measures like ASLR are effective mitigations.
NOTE: this attack can only take place after authentication, so peers behind
CURVE/GSSAPI are not vulnerable to unauthenticated attackers."