### PR TITLE
Fixes/2FAPeriod

### DIFF
--- a/src/qt/2faconfirmdialog.cpp
+++ b/src/qt/2faconfirmdialog.cpp
@@ -111,10 +111,6 @@ void TwoFAConfirmDialog::on_acceptCode()
     if (codeSetting != "") {
         if (code != codeSetting)
             return;
-
-        QDateTime current = QDateTime::currentDateTime();
-        settings.setValue("2FALastTime", current.toTime_t());
     }
-
     accept();
 }

--- a/src/qt/2faqrdialog.cpp
+++ b/src/qt/2faqrdialog.cpp
@@ -61,9 +61,10 @@ void TwoFAQRDialog::update()
     for (char c : address.ToString()) {
         if (!std::isdigit(c)) addr += c;
     }
-
+    QString periodSetting = settings.value("2FAPeriod").toString();
     QString uri;
-    uri.sprintf("otpauth://totp/dapscoin:test@test.com?secret=%s&issuer=dapscoin&algorithm=SHA1&digits=6&period=30", addr.c_str());
+    uri.sprintf("otpauth://totp/dapscoin:test@test.com?secret=%s&issuer=dapscoin&algorithm=SHA1&digits=6&period=", addr.c_str());
+    uri += periodSetting;
     ui->lblURI->setText(uri);
 
 #ifdef USE_QRCODE

--- a/src/qt/2faqrdialog.cpp
+++ b/src/qt/2faqrdialog.cpp
@@ -63,7 +63,7 @@ void TwoFAQRDialog::update()
     }
     QString periodSetting = settings.value("2FAPeriod").toString();
     QString uri;
-    uri.sprintf("otpauth://totp/dapscoin:test@test.com?secret=%s&issuer=dapscoin&algorithm=SHA1&digits=6&period=", addr.c_str());
+    uri.sprintf("otpauth://totp/DAPScoin:QT%20Wallet?secret=%s&issuer=dapscoin&algorithm=SHA1&digits=6&period=", addr.c_str());
     uri += periodSetting;
     ui->lblURI->setText(uri);
 

--- a/src/qt/2faqrdialog.h
+++ b/src/qt/2faqrdialog.h
@@ -29,6 +29,7 @@ private slots:
 private:
     Ui::TwoFAQRDialog *ui;
     WalletModel* model;
+    QSettings settings;
 };
 
 #endif // TWOFAQRDIALOG_H

--- a/src/qt/2faqrdialog.h
+++ b/src/qt/2faqrdialog.h
@@ -2,6 +2,7 @@
 #define TWOFAQRDIALOG_H
 
 #include <QDialog>
+#include <QSettings>
 
 class WalletModel;
 

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -313,6 +313,8 @@ void OptionsPage::qrDialogIsFinished(int result) {
 void OptionsPage::dialogIsFinished(int result) {
    if(result == QDialog::Accepted){
         settings.setValue("2FA", "enabled");
+        QDateTime current = QDateTime::currentDateTime();
+        settings.setValue("2FALastTime", current.toTime_t());
         enable2FA();
 
         QMessageBox::information(this, tr("SUCCESS!"),

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -334,10 +334,6 @@ void OptionsPage::changeTheme(ToggleButton* widget)
 }
 
 void OptionsPage::disable2FA() {
-    ui->btn_day->setEnabled(false);
-    ui->btn_week->setEnabled(false);
-    ui->btn_month->setEnabled(false);
-
     ui->code_1->setText("");
     ui->code_2->setText("");
     ui->code_3->setText("");
@@ -355,10 +351,6 @@ void OptionsPage::disable2FA() {
 }
 
 void OptionsPage::enable2FA() {
-    ui->btn_day->setEnabled(true);
-    ui->btn_week->setEnabled(true);
-    ui->btn_month->setEnabled(true);
-
     ui->label_3->setEnabled(true);
     ui->label_4->setEnabled(true);
     ui->label->setEnabled(true);

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -384,16 +384,16 @@ void OptionsPage::enable2FA() {
      
     int period = settings.value("2FAPeriod").toInt();
     if (period == 1)
-        ui->btn_day->setStyleSheet("border-color: red;");
+        ui->btn_day->setStyleSheet("border-color: green;");
     else if (period == 7)
-        ui->btn_week->setStyleSheet("border-color: red;");
+        ui->btn_week->setStyleSheet("border-color: green;");
     else if (period == 30)
-        ui->btn_month->setStyleSheet("border-color: red;");
+        ui->btn_month->setStyleSheet("border-color: green;");
 }
 
 void OptionsPage::on_day() {
     settings.setValue("2FAPeriod", "1");
-    ui->btn_day->setStyleSheet("border-color: red;");
+    ui->btn_day->setStyleSheet("border-color: green;");
     ui->btn_week->setStyleSheet("border-color: white;");
     ui->btn_month->setStyleSheet("border-color: white;");
 }
@@ -401,7 +401,7 @@ void OptionsPage::on_day() {
 void OptionsPage::on_week() {
     settings.setValue("2FAPeriod", "7");
     ui->btn_day->setStyleSheet("border-color: white;");
-    ui->btn_week->setStyleSheet("border-color: red;");
+    ui->btn_week->setStyleSheet("border-color: green;");
     ui->btn_month->setStyleSheet("border-color: white;");
 }
 
@@ -409,5 +409,5 @@ void OptionsPage::on_month() {
     settings.setValue("2FAPeriod", "30");
     ui->btn_day->setStyleSheet("border-color: white;");
     ui->btn_week->setStyleSheet("border-color: white;");
-    ui->btn_month->setStyleSheet("border-color: red;");
+    ui->btn_month->setStyleSheet("border-color: green;");
 }

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -385,7 +385,7 @@ void OptionsPage::enable2FA() {
         ui->btn_day->setStyleSheet("border-color: red;");
     else if (period == 7)
         ui->btn_week->setStyleSheet("border-color: red;");
-    else if (period == 31)
+    else if (period == 30)
         ui->btn_month->setStyleSheet("border-color: red;");
 }
 
@@ -404,7 +404,7 @@ void OptionsPage::on_week() {
 }
 
 void OptionsPage::on_month() {
-    settings.setValue("2FAPeriod", "31");
+    settings.setValue("2FAPeriod", "30");
     ui->btn_day->setStyleSheet("border-color: white;");
     ui->btn_week->setStyleSheet("border-color: white;");
     ui->btn_month->setStyleSheet("border-color: red;");


### PR DESCRIPTION
- 2FA link had 30 days in the string, changed to use 2FAPeriod settings
- changed 1 month == 30 days (easily reverted if 31 is preferred)
- Change 2FA test@test.com info to "DAPSCoin:QT Wallet"
- Move 2FALastTime to optiongspage.cpp
- Remove disable/enable 2FA Period buttons -  I think they should be enabled all the time - makes more sense instead of having the user enable 2FA with 1 day as default, then disable and re-enable to change it to the setting of their choice
- Change selected 2FA Period button border to green instead of red

Options Page:
![image](https://user-images.githubusercontent.com/2319897/61258234-96ba9080-a742-11e9-92e3-d75f13eb0616.png)

Registry:
![image](https://user-images.githubusercontent.com/2319897/61258255-af2aab00-a742-11e9-9315-c2dfd2b252ef.png)
