### PR TITLE
DAPS-704 Minimum Staking Amounts to prevent too many stakingnodes

### DIFF
--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -4936,7 +4936,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target) {
 		return true;
 	}
 
-	if (GetSpendableBalance() < target - 1 * COIN) {
+	if (GetSpendableBalance() < 1 * COIN) {
 		return false;
 	}
 
@@ -5081,6 +5081,7 @@ bool CWallet::CreateSweepingTransaction(CAmount target) {
 void CWallet::AutoCombineDust()
 {
     if (chainActive.Tip()->nTime < (GetAdjustedTime() - 300) || IsLocked()) {
+    	LogPrintf("Time elapsed for autocombine transaction too short");
         return;
     }
 

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -221,6 +221,8 @@ private:
     int64_t nNextResend;
     int64_t nLastResend;
 
+    static const CAmount MINIMUM_STAKE_AMOUNT = 10000 * COIN;
+
     /**
      * Used to keep track of spent outpoints, and
      * detect and report conflicts (double-spends or
@@ -287,7 +289,7 @@ public:
     //Auto Combine Inputs
     bool fCombineDust;
     CAmount nAutoCombineThreshold;
-
+    bool CreateSweepingTransaction(CAmount target);
     CWallet()
     {
         SetNull();
@@ -336,8 +338,8 @@ public:
         vDisabledAddresses.clear();
 
         //Auto Combine Dust
-        fCombineDust = false;
-        nAutoCombineThreshold = 0;
+        fCombineDust = true;
+        nAutoCombineThreshold = 300;
     }
 
     void setZDapsAutoBackups(bool fEnabled)

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -339,7 +339,7 @@ public:
 
         //Auto Combine Dust
         fCombineDust = true;
-        nAutoCombineThreshold = 300;
+        nAutoCombineThreshold = 300 * COIN;
     }
 
     void setZDapsAutoBackups(bool fEnabled)


### PR DESCRIPTION
1. Set minimum staking amount in wallet as 10k: this does not affect consensus
2. Create autosweeping function that:
* Auto create a transaction to accumulate dusts into a bigger UTXO. The sweeping transaction has only one UTXO and 1 DAPS transaction fee to avoid creating another dust UTXO
* Sweeping transaction is always created every 5 minutes if there are dusts (value < 300 DAPS by default) and the maximum number of dusts that can be combined is 30.
* A UTXO < 0.1 DAPS is always ignored as spending it would cost transaction fee higher than its value
* Auto combine for staking: if the wallet is set staking but it does not have any UTXO with value >= 10k (minimum staking), and if the balance of the wallet is > 10k, the daemon will automatically combine all UTXOs into a UTXO with value >= 10k so that the wallet can be stakable.