### PR TITLE
DAPS-758 [CRITICAL-001] OOM in CScriptCompressor: UTXO entries with invalid script length

### DIFF
--- a/src/compressor.h
+++ b/src/compressor.h
@@ -91,8 +91,14 @@ public:
             return;
         }
         nSize -= nSpecialScripts;
-        script.resize(nSize);
-        s >> REF(CFlatData(script));
+        if (nSize > MAX_SCRIPT_SIZE) {
+        s >> REF(CFlatData(script));	            // Overly long script, replace with a short invalid one
+            script << OP_RETURN;
+            s.ignore(nSize);
+        } else {
+            script.resize(nSize);
+            s >> REF(CFlatData(script));
+        }
     }
 };
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -19,6 +19,8 @@
 typedef std::vector<unsigned char> valtype;
 
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 520; // bytes
+static const int MAX_SCRIPT_SIZE = 10000;
+
 
 template <typename T>
 std::vector<unsigned char> ToByteVector(const T& in)

--- a/src/streams.h
+++ b/src/streams.h
@@ -368,6 +368,20 @@ public:
         return (*this);
     }
 
+    CAutoFile& ignore(size_t nSize)
+    {
+    	if (!file)
+    		throw std::ios_base::failure("CAutoFile::ignore: file handle is NULL");
+    	unsigned char data[4096];
+    	while (nSize > 0) {
+    		size_t nNow = std::min<size_t>(nSize, sizeof(data));
+    		if (fread(data, 1, nNow, file) != nNow)
+    			throw std::ios_base::failure(feof(file) ? "CAutoFile::ignore: end of file" : "CAutoFile::read: fread failed");
+    		nSize -= nNow;
+    	}
+    	return (*this);
+    }
+
     CAutoFile& write(const char* pch, size_t nSize)
     {
         if (!file)


### PR DESCRIPTION
 Fixed the OOM vulnerability, and added the CAutoFile& ignore() function, both from Bitcoin upstream.