### PR TITLE
DAPS-767 [CRITICAL-002] Inconsistent and reusable signature scheme

### DIFF
--- a/src/activemasternode.cpp
+++ b/src/activemasternode.cpp
@@ -204,8 +204,10 @@ bool CActiveMasternode::SendMasternodePing(std::string& errorMessage)
         std::string retErrorMessage;
         std::vector<unsigned char> vchMasterNodeSignature;
         int64_t masterNodeSignatureTime = GetAdjustedTime();
-
-        std::string strMessage = service.ToString() + boost::lexical_cast<std::string>(masterNodeSignatureTime) + boost::lexical_cast<std::string>(false);
+        std::string ss = service.ToString();
+        bool val = false;
+        uint256 h = Hash(BEGIN(ss), END(ss), BEGIN(masterNodeSignatureTime), END(masterNodeSignatureTime), BEGIN(val), END(val));
+        std::string strMessage = h.GetHex();
 
         if (!obfuScationSigner.SignMessage(strMessage, retErrorMessage, vchMasterNodeSignature, keyMasternode)) {
             errorMessage = "dseep sign message failed: " + retErrorMessage;
@@ -304,8 +306,9 @@ bool CActiveMasternode::CreateBroadcast(CTxIn vin, CService service, CKey keyCol
 
     std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
     std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
-
-    std::string strMessage = service.ToString() + boost::lexical_cast<std::string>(masterNodeSignatureTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(PROTOCOL_VERSION) + donationAddress + boost::lexical_cast<std::string>(donationPercantage);
+    std::string ss = service.ToString();
+    uint256 h = Hash(BEGIN(ss), END(ss), BEGIN(masterNodeSignatureTime), END(masterNodeSignatureTime), BEGIN(vchPubKey), END(vchPubKey), BEGIN(PROTOCOL_VERSION), END(PROTOCOL_VERSION), BEGIN(donationPercantage), END(donationPercantage));
+    std::string strMessage = h.GetHex() + vchPubKey + vchPubKey2;
     LogPrintf("\nCActiveMasternode::CreateBroadcast: sign key = %s, strMessage=%s\n", pubKeyCollateralAddress.GetHex(), strMessage);
     LogPrintf("\nCActiveMasternode::CreateBroadcast: masternode key = %s, strMessage=%s\n", pubKeyMasternode.GetHex(), strMessage);
     if (!obfuScationSigner.SignMessage(strMessage, retErrorMessage, vchMasterNodeSignature, keyCollateralAddress)) {

--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -466,16 +466,15 @@ bool CMasternodePaymentWinner::Sign(CKey& keyMasternode, CPubKey& pubKeyMasterno
     std::string errorMessage;
     std::string strMasterNodeSignMessage;
     std::string payeeString(payee.begin(), payee.end());
-    std::string strMessage = vinMasternode.prevout.ToStringShort() +
-                             boost::lexical_cast<std::string>(nBlockHeight) +
-							 payeeString;
+    uint256 hashPrevout = vinMasternode.prevout.GetHash();
+    uint256 h = Hash(hashPrevout.begin(), hashPrevout.end(), BEGIN(nBlockHeight), END(nBlockHeight), payee.begin(), payee.end());
 
-    if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
+    if (!obfuScationSigner.SignMessage(h.GetHex(), errorMessage, vchSig, keyMasternode)) {
         LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage.c_str());
         return false;
     }
 
-    if (!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)) {
+    if (!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, h.GetHex(), errorMessage)) {
         LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage.c_str());
         return false;
     }
@@ -799,9 +798,9 @@ bool CMasternodePaymentWinner::SignatureValid()
 
     if (pmn != NULL) {
     	std::string payeeString(payee.begin(), payee.end());
-        std::string strMessage = vinMasternode.prevout.ToStringShort() +
-                                 boost::lexical_cast<std::string>(nBlockHeight) +
-                                 payeeString;
+    	uint256 prevoutHash = vinMasternode.prevout.GetHash();
+    	uint256 h = Hash(prevoutHash.begin(), prevoutHash.end(), BEGIN(nBlockHeight), END(nBlockHeight), payee.begin(), payee.end());
+        std::string strMessage = h.GetHex();
 
         std::string errorMessage = "";
         if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {

--- a/src/masternode.cpp
+++ b/src/masternode.cpp
@@ -473,7 +473,8 @@ bool CMasternodeBroadcast::CheckAndUpdate(int& nDos)
 
     std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
     std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
-    std::string strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
+    std::string ss = addr.ToString();
+    std::string strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime), pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end(), pubKeyMasternode.begin(), pubKeyMasternode.end(), BEGIN(protocolVersion), END(protocolVersion)).GetHex();
 
     if (protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) {
         LogPrint("masternode","mnb - ignoring outdated Masternode %s protocol version %d\n", vin.prevout.hash.ToString(), protocolVersion);
@@ -650,8 +651,8 @@ bool CMasternodeBroadcast::Sign(CKey& keyCollateralAddress)
     std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
 
     sigTime = GetAdjustedTime();
-
-    std::string strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
+    std::string ss = addr.ToString();
+    std::string strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime), pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end(), pubKeyMasternode.begin(), pubKeyMasternode.end(), BEGIN(protocolVersion), END(protocolVersion)).GetHex();
 
     if (!obfuScationSigner.SignMessage(strMessage, errorMessage, sig, keyCollateralAddress)) {
         LogPrint("masternode","CMasternodeBroadcast::Sign() - Error: %s\n", errorMessage);
@@ -681,9 +682,8 @@ std::string CMasternodeBroadcast::GetOldStrMessage()
 {
     std::string strMessage;
 
-    std::string vchPubKey(pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end());
-    std::string vchPubKey2(pubKeyMasternode.begin(), pubKeyMasternode.end());
-    strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + vchPubKey + vchPubKey2 + boost::lexical_cast<std::string>(protocolVersion);
+    std::string ss = addr.ToString();
+    strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime),  pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end(), pubKeyMasternode.begin(), pubKeyMasternode.end(), BEGIN(protocolVersion), END(protocolVersion)).GetHex();
 
     return strMessage;
 }
@@ -691,8 +691,8 @@ std::string CMasternodeBroadcast::GetOldStrMessage()
 std:: string CMasternodeBroadcast::GetNewStrMessage()
 {
     std::string strMessage;
-
-    strMessage = addr.ToString() + boost::lexical_cast<std::string>(sigTime) + pubKeyCollateralAddress.GetID().ToString() + pubKeyMasternode.GetID().ToString() + boost::lexical_cast<std::string>(protocolVersion);
+    std::string ss = addr.ToString();
+    strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime), pubKeyCollateralAddress.begin(), pubKeyCollateralAddress.end(), pubKeyMasternode.begin(), pubKeyMasternode.end(), BEGIN(protocolVersion), END(protocolVersion)).GetHex();
 
     return strMessage;
 }
@@ -721,7 +721,8 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
     std::string strMasterNodeSignMessage;
 
     sigTime = GetAdjustedTime();
-    std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
+    std::string vinStr = vin.ToString();
+    std::string strMessage = Hash(BEGIN(vinStr), END(vinStr), blockHash.begin(), blockHash.end(), BEGIN(sigTime), END(sigTime)).GetHex();
 
     if (!obfuScationSigner.SignMessage(strMessage, errorMessage, vchSig, keyMasternode)) {
         LogPrint("masternode","CMasternodePing::Sign() - Error: %s\n", errorMessage);
@@ -737,7 +738,8 @@ bool CMasternodePing::Sign(CKey& keyMasternode, CPubKey& pubKeyMasternode)
 }
 
 bool CMasternodePing::VerifySignature(CPubKey& pubKeyMasternode, int &nDos) {
-    std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
+	std::string vinStr = vin.ToString();
+    std::string strMessage = Hash(BEGIN(vinStr), END(vinStr), blockHash.begin(), blockHash.end(), BEGIN(sigTime), END(sigTime)).GetHex();
     std::string errorMessage = "";
 
     if(!obfuScationSigner.VerifyMessage(pubKeyMasternode, vchSig, strMessage, errorMessage)){
@@ -771,7 +773,8 @@ bool CMasternodePing::CheckAndUpdate(int& nDos, bool fRequireEnabled)
         // update only if there is no known ping for this masternode or
         // last ping was more then MASTERNODE_MIN_MNP_SECONDS-60 ago comparing to this one
         if (!pmn->IsPingedWithin(MASTERNODE_MIN_MNP_SECONDS - 60, sigTime)) {
-            std::string strMessage = vin.ToString() + blockHash.ToString() + boost::lexical_cast<std::string>(sigTime);
+        	std::string vinStr = vin.ToString();
+            std::string strMessage = Hash(BEGIN(vinStr), END(vinStr), blockHash.begin(), blockHash.end(), BEGIN(sigTime), END(sigTime)).GetHex();
 
             std::string errorMessage = "";
             if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {

--- a/src/masternodeman.cpp
+++ b/src/masternodeman.cpp
@@ -915,8 +915,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
 
         std::string vchPubKey(pubkey.begin(), pubkey.end());
         std::string vchPubKey2(pubkey2.begin(), pubkey2.end());
-
-        strMessage = addr.ToString() + std::to_string(sigTime) + vchPubKey + vchPubKey2 + std::to_string(protocolVersion) + donationAddress.ToString() + std::to_string(donationPercentage);
+        std::string ss = addr.ToString();
+        strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime), pubkey.begin(), pubkey.end(), pubkey2.begin(), pubkey2.end(), BEGIN(protocolVersion), END(protocolVersion), BEGIN(donationAddress), END(donationAddress), BEGIN(donationPercentage), END(donationPercentage)).GetHex();
 
         if (protocolVersion < masternodePayments.GetMinMasternodePaymentsProto()) {
             LogPrint("masternode","dsee - ignoring outdated Masternode %s protocol version %d < %d\n", vin.prevout.hash.ToString(), protocolVersion, masternodePayments.GetMinMasternodePaymentsProto());
@@ -1106,7 +1106,8 @@ void CMasternodeMan::ProcessMessage(CNode* pfrom, std::string& strCommand, CData
         if (pmn != NULL && pmn->protocolVersion >= masternodePayments.GetMinMasternodePaymentsProto()) {
             // take this only if it's newer
             if (sigTime - pmn->nLastDseep > MASTERNODE_MIN_MNP_SECONDS) {
-                std::string strMessage = pmn->addr.ToString() + boost::lexical_cast<std::string>(sigTime) + boost::lexical_cast<std::string>(stop);
+            	std::string ss = pmn->addr.ToString();
+                std::string strMessage = Hash(BEGIN(ss), END(ss), BEGIN(sigTime), END(sigTime), BEGIN(stop), END(stop)).GetHex();
 
                 std::string errorMessage = "";
                 if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {

--- a/src/obfuscation-relay.cpp
+++ b/src/obfuscation-relay.cpp
@@ -35,7 +35,9 @@ std::string CObfuScationRelay::ToString()
 
 bool CObfuScationRelay::Sign(std::string strSharedKey)
 {
-    std::string strMessage = in.ToString() + out.ToString();
+	std::string inString = in.ToString();
+	std::string outString = out.ToString();
+    std::string strMessage = Hash(BEGIN(inString), END(inString), BEGIN(outString), END(outString)).GetHex();
 
     CKey key2;
     CPubKey pubkey2;
@@ -61,7 +63,9 @@ bool CObfuScationRelay::Sign(std::string strSharedKey)
 
 bool CObfuScationRelay::VerifyMessage(std::string strSharedKey)
 {
-    std::string strMessage = in.ToString() + out.ToString();
+	std::string inString = in.ToString();
+	std::string outString = out.ToString();
+	std::string strMessage = Hash(BEGIN(inString), END(inString), BEGIN(outString), END(outString)).GetHex();
 
     CKey key2;
     CPubKey pubkey2;

--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -598,7 +598,7 @@ void CObfuscationPool::CheckFinalTransaction()
         // sign a message
 
         int64_t sigTime = GetAdjustedTime();
-        std::string strMessage = txNew.GetHash().ToString() + boost::lexical_cast<std::string>(sigTime);
+        std::string strMessage = Hash(txNew.GetHash().begin(), txNew.GetHash().end(), BEGIN(sigTime), END(sigTime)).GetHex();
         std::string strError = "";
         std::vector<unsigned char> vchSig;
         CKey key2;
@@ -1913,8 +1913,8 @@ bool CObfuScationSigner::VerifyMessage(CPubKey pubkey, vector<unsigned char>& vc
 bool CObfuscationQueue::Sign()
 {
     if (!fMasterNode) return false;
-
-    std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
+    std::string ss = vin.ToString();
+    std::string strMessage = Hash(BEGIN(ss), END(ss), BEGIN(nDenom), END(nDenom), BEGIN(time), END(time), BEGIN(ready), END(ready)).GetHex();
 
     CKey key2;
     CPubKey pubkey2;
@@ -1954,7 +1954,8 @@ bool CObfuscationQueue::CheckSignature()
     CMasternode* pmn = mnodeman.Find(vin);
 
     if (pmn != NULL) {
-        std::string strMessage = vin.ToString() + boost::lexical_cast<std::string>(nDenom) + boost::lexical_cast<std::string>(time) + boost::lexical_cast<std::string>(ready);
+    	std::string vinStr = vin.ToString();
+        std::string strMessage = Hash(BEGIN(vinStr), END(vinStr), BEGIN(nDenom), END(nDenom), BEGIN(time), END(time), BEGIN(ready), END(ready)).GetHex();
 
         std::string errorMessage = "";
         if (!obfuScationSigner.VerifyMessage(pmn->pubKeyMasternode, vchSig, strMessage, errorMessage)) {

--- a/src/spork.cpp
+++ b/src/spork.cpp
@@ -176,7 +176,7 @@ void ReprocessBlocks(int nBlocks)
 bool CSporkManager::CheckSignature(CSporkMessage& spork)
 {
     //note: need to investigate why this is failing
-    std::string strMessage = boost::lexical_cast<std::string>(spork.nSporkID) + boost::lexical_cast<std::string>(spork.nValue) + boost::lexical_cast<std::string>(spork.nTimeSigned);
+    std::string strMessage = Hash(BEGIN(spork.nSporkID), END(spork.nSporkID), BEGIN(spork.nValue), END(spork.nValue), BEGIN(spork.nTimeSigned), END(spork.nTimeSigned)).GetHex();
     CPubKey pubkeynew(ParseHex(Params().SporkKey()));
     std::string errorMessage = "";
     if (obfuScationSigner.VerifyMessage(pubkeynew, spork.vchSig, strMessage, errorMessage)) {
@@ -188,7 +188,7 @@ bool CSporkManager::CheckSignature(CSporkMessage& spork)
 
 bool CSporkManager::Sign(CSporkMessage& spork)
 {
-    std::string strMessage = boost::lexical_cast<std::string>(spork.nSporkID) + boost::lexical_cast<std::string>(spork.nValue) + boost::lexical_cast<std::string>(spork.nTimeSigned);
+    std::string strMessage = Hash(BEGIN(spork.nSporkID), END(spork.nSporkID), BEGIN(spork.nValue), END(spork.nValue), BEGIN(spork.nTimeSigned), END(spork.nTimeSigned)).GetHex();
 
     CKey key2;
     CPubKey pubkey2;

--- a/src/swifttx.cpp
+++ b/src/swifttx.cpp
@@ -457,7 +457,7 @@ uint256 CConsensusVote::GetHash() const
 bool CConsensusVote::SignatureValid()
 {
     std::string errorMessage;
-    std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
+    std::string strMessage = Hash(txHash.begin(), txHash.end(), BEGIN(nBlockHeight), END(nBlockHeight)).ToString();
 
     CMasternode* pmn = mnodeman.Find(vinMasternode);
 
@@ -480,7 +480,7 @@ bool CConsensusVote::Sign()
 
     CKey key2;
     CPubKey pubkey2;
-    std::string strMessage = txHash.ToString().c_str() + boost::lexical_cast<std::string>(nBlockHeight);
+    std::string strMessage = Hash(txHash.begin(), txHash.end(), BEGIN(nBlockHeight), END(nBlockHeight)).GetHex();
 
     if (!obfuScationSigner.SetKey(strMasterNodePrivKey, errorMessage, key2, pubkey2)) {
         LogPrintf("CConsensusVote::Sign() - ERROR: Invalid masternodeprivkey: '%s'\n", errorMessage.c_str());


### PR DESCRIPTION
Converted binary data payload from a string to a hash for use in the signature scheme.