### PR TITLE
DAPS-872 QT crashes upon resynchronization if positive balance, but not unlocked

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2749,7 +2749,6 @@ ConnectBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindex, 
     // Check it again in case a previous version let a bad block in
     if (!fAlreadyChecked && !CheckBlock(block, state, !fJustCheck, !fJustCheck))
         return false;
-
     //move this code from checkBlock to ConnectBlock functions to check for forks
     //Check PoA block time
     if (block.IsPoABlockByVersion() && !CheckPoAblockTime(block)) {
@@ -2880,7 +2879,7 @@ ConnectBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindex, 
                                          REJECT_DUPLICATE, "bad-txns-inputs-spent");
                 }
                 pblocktree->WriteKeyImage(keyImage.GetHex(), bh);
-                if (pwalletMain != NULL) {
+                if (pwalletMain != NULL && !pwalletMain->IsLocked()) {
                     if (pwalletMain->GetDebit(in, ISMINE_ALL)) {
                         pwalletMain->keyImagesSpends[keyImage.GetHex()] = true;
                     }
@@ -2919,6 +2918,9 @@ ConnectBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindex, 
 		const CTransaction coinstake = block.vtx[1];
 		size_t numUTXO = coinstake.vout.size();
 		CAmount posBlockReward = PoSBlockReward();
+		if (mapBlockIndex.count(block.hashPrevBlock) < 1) {
+			return state.DoS(100, error("ConnectBlock() : Previous block not found, received block %s, previous %s, current tip %s", block.GetHash().GetHex(), block.hashPrevBlock.GetHex(), chainActive.Tip()->GetBlockHash().GetHex()));
+		}
 		int thisBlockHeight = mapBlockIndex[block.hashPrevBlock]->nHeight + 1; //avoid potential block disorder during download
 		CAmount blockValue = GetBlockValue(thisBlockHeight - 1);
 		if (blockValue > posBlockReward) {
@@ -2926,21 +2928,21 @@ ConnectBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindex, 
 			const CTxOut& mnOut = coinstake.vout[numUTXO - 2];
 			std::string mnsa(mnOut.masternodeStealthAddress.begin(), mnOut.masternodeStealthAddress.end());
 			if (!VerifyDerivedAddress(mnOut, mnsa))
-				return state.DoS(100, error("CheckBlock() : Incorrect derived address for masternode rewards"));
+				return state.DoS(100, error("ConnectBlock() : Incorrect derived address for masternode rewards"));
 
 			CAmount teamReward = blockValue - posBlockReward;
 			const CTxOut& foundationOut = coinstake.vout[numUTXO - 1];
 			if (foundationOut.nValue != teamReward)
-				return state.DoS(100, error("CheckBlock() : Incorrect amount PoS rewards for foundation, reward = %d while the correct reward = %d", foundationOut.nValue, teamReward));
+				return state.DoS(100, error("ConnectBlock() : Incorrect amount PoS rewards for foundation, reward = %d while the correct reward = %d", foundationOut.nValue, teamReward));
 
 			if (!VerifyDerivedAddress(foundationOut, FOUNDATION_WALLET))
-				return state.DoS(100, error("CheckBlock() : Incorrect derived address PoS rewards for foundation"));
+				return state.DoS(100, error("ConnectBlock() : Incorrect derived address PoS rewards for foundation"));
 		} else {
 			//there is no team rewards in this block
 			const CTxOut& mnOut = coinstake.vout[numUTXO - 1];
 			std::string mnsa(mnOut.masternodeStealthAddress.begin(), mnOut.masternodeStealthAddress.end());
 			if (!VerifyDerivedAddress(mnOut, mnsa))
-				return state.DoS(100, error("CheckBlock() : Incorrect derived address for masternode rewards"));
+				return state.DoS(100, error("ConnectBlock() : Incorrect derived address for masternode rewards"));
 		}
     }
 

--- a/src/wallet.cpp
+++ b/src/wallet.cpp
@@ -970,6 +970,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction& tx, const CBlock* pbl
 
 void CWallet::SyncTransaction(const CTransaction& tx, const CBlock* pblock)
 {
+	if (IsLocked()) return;
     LOCK2(cs_main, cs_wallet);
     if (!AddToWalletIfInvolvingMe(tx, pblock, true)) {
         return; // Not one of ours


### PR DESCRIPTION
Check that wallet is unlocked before adding TX to the wallet.