### PR TITLE
Settings > Toggle Switches: Regression, On / Off texts missing - Remove stdset="0" for toggle buttons

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -50,13 +50,13 @@
      <property name="layoutDirection">
       <enum>Qt::LeftToRight</enum>
      </property>
-     <property name="OptionA" stdset="0">
+     <property name="OptionA">
       <string>Dark</string>
      </property>
-     <property name="OptionB" stdset="0">
+     <property name="OptionB">
       <string>Light</string>
      </property>
-     <property name="fixedSize" stdset="0">
+     <property name="fixedSize">
       <size>
        <width>100</width>
        <height>55</height>
@@ -91,13 +91,13 @@
      <property name="layoutDirection">
       <enum>Qt::LeftToRight</enum>
      </property>
-     <property name="OptionA" stdset="0">
+     <property name="OptionA">
       <string>On</string>
      </property>
-     <property name="OptionB" stdset="0">
+     <property name="OptionB">
       <string>Off</string>
      </property>
-     <property name="fixedSize" stdset="0">
+     <property name="fixedSize">
       <size>
        <width>100</width>
        <height>55</height>
@@ -333,13 +333,13 @@
        <verstretch>0</verstretch>
       </sizepolicy>
      </property>
-     <property name="OptionA" stdset="0">
+     <property name="OptionA">
       <string>On</string>
      </property>
-     <property name="OptionB" stdset="0">
+     <property name="OptionB">
       <string>Off</string>
      </property>
-     <property name="fixedSize" stdset="0">
+     <property name="fixedSize">
       <size>
        <width>100</width>
        <height>55</height>


### PR DESCRIPTION
- Remove stdset="0" for toggle buttons: Causes the Off/On, Dark/Light text not to be shown in toggle buttons
![image](https://user-images.githubusercontent.com/2319897/64302973-d4be7e80-cf53-11e9-88ce-06d993956f51.png)

Fixed version:
![image](https://user-images.githubusercontent.com/2319897/64303035-2c5cea00-cf54-11e9-854b-d09f5a3ff968.png)

