### PR TITLE
DAPS-905 - The Create Passphrase confirmation dialog does not look like typical DAPS designs

### DIFF
--- a/src/qt/encryptdialog.cpp
+++ b/src/qt/encryptdialog.cpp
@@ -33,7 +33,7 @@ void EncryptDialog::setModel(WalletModel* model)
 void EncryptDialog::closeEvent (QCloseEvent *event)
 {
     QMessageBox::StandardButton reply;
-    reply = QMessageBox::warning(this, "Wallet encryption required", "There was no passphrase entered for the wallet. Wallet encryption is required for the security of your funds. What would you like to do?", QMessageBox::Retry|QMessageBox::Close);
+    reply = QMessageBox::warning(this, "Wallet encryption required", "There was no passphrase entered for the wallet.\n\nWallet encryption is required for the security of your funds.\n\nWhat would you like to do?", QMessageBox::Retry|QMessageBox::Close);
       if (reply == QMessageBox::Retry) {
       event->ignore();
       } else {
@@ -44,7 +44,7 @@ void EncryptDialog::closeEvent (QCloseEvent *event)
 void EncryptDialog::on_btnCancel()
 {
     QMessageBox::StandardButton reply;
-    reply = QMessageBox::warning(this, "Wallet encryption required", "There was no passphrase entered for the wallet. Wallet encryption is required for the security of your funds. What would you like to do?", QMessageBox::Retry|QMessageBox::Close);
+    reply = QMessageBox::warning(this, "Wallet encryption required", "There was no passphrase entered for the wallet.\n\nWallet encryption is required for the security of your funds.\n\nWhat would you like to do?", QMessageBox::Retry|QMessageBox::Close);
       if (reply == QMessageBox::Retry) {
       return;
       } else {

--- a/src/qt/encryptdialog.cpp
+++ b/src/qt/encryptdialog.cpp
@@ -90,7 +90,7 @@ void EncryptDialog::on_acceptPassphrase() {
 
         if (model->setWalletEncrypted(true, newPass))
             QMessageBox::information(this, tr("Wallet encryption successful"),
-                    tr("Wallet passphrase was successfully set. Please remember your passphrase as there is no way to recover it."));
+                    tr("Wallet passphrase was successfully set.\n Please remember your passphrase as there is no way to recover it."));
         accept();
     } else {
             QMessageBox::critical(this, tr("Wallet encryption failed"),


### PR DESCRIPTION
- Add line break to successful passphrase confirmation

![image](https://user-images.githubusercontent.com/2319897/64746875-4742d780-d4db-11e9-9cd4-7b7e35cf093d.png)
