### PR TITLE
Codefresh: Add npm audit fix for block explorer

### DIFF
--- a/boot/cf/explorer.Dockerfile
+++ b/boot/cf/explorer.Dockerfile
@@ -20,7 +20,8 @@ RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.33.11/install.
     [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
     nvm install 10 && \
     cd /DAPS/ && \
-    npm install
+    npm install && \
+    npm audit fix
 
 EXPOSE 3001
 


### PR DESCRIPTION
- Add npm audit fix

Log from explorer container:
"added 894 packages from 401 contributors and audited 7824 packages in 11.355s                                                            
found 267 vulnerabilities (11 low, 6 moderate, 250 high)                                                                                 
  run `npm audit fix` to fix them, or `npm audit` for details  "