### PR TITLE
DAPS-859 QT > Settings: "Not enough mintable coins" dialogue is illegible

### DIFF
--- a/src/qt/optionspage.h
+++ b/src/qt/optionspage.h
@@ -53,7 +53,7 @@ public:
     void setModel(WalletModel* model);
     void setMapper();
     bool matchNewPasswords();
-    StakingStatusError getStakingStatusError(QStringList&);
+    StakingStatusError getStakingStatusError(QString&);
 
 public slots:
     void on_EnableStaking(ToggleButton*);

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -652,32 +652,32 @@ bool WalletModel::isMine(CBitcoinAddress address)
     return IsMine(*wallet, address.Get());
 }
 
-StakingStatusError WalletModel::getStakingStatusError(QStringList& errors)
+StakingStatusError WalletModel::getStakingStatusError(QString& error)
 {
     // int timeRemaining = (1471482000 - chainActive.Tip()->nTime) / (60 * 60); //time remaining in hrs
     if (1471482000 > chainActive.Tip()->nTime) {
-        errors.push_back(QString(tr("Chain has not matured. Hours remaining: ")) + QString((1471482000 - chainActive.Tip()->nTime) / (60 * 60)));
+        error = "Chain has not matured.\nHours remaining: " + QString((1471482000 - chainActive.Tip()->nTime) / (60 * 60));
         return StakingStatusError::DEFAULT;
     } else if (vNodes.empty()) {
-        errors.push_back(QString(tr("No peer connections. Please check network.")));
+        error = "No peer connections.\nPlease check network settings.";
         return StakingStatusError::DEFAULT;
     } else {
     	bool fMintable = pwalletMain->MintableCoins();
     	CAmount balance = pwalletMain->GetBalance();
     	if (!fMintable || nReserveBalance > balance) {
     		if (balance < CWallet::MINIMUM_STAKE_AMOUNT + 10*COIN) {
-    			errors.push_back(QString(tr("Balance is under staking thresh hold, please send more DAPS to this wallet")));
+    			error = "\nBalance is under the minimum 400,000 staking threshold.\nPlease send more DAPS to this wallet.\n";
     			return StakingStatusError::DEFAULT;
     		}
     		if (nReserveBalance > balance || (balance > nReserveBalance && balance - nReserveBalance < CWallet::MINIMUM_STAKE_AMOUNT)) {
-    			errors.push_back(QString(tr("Reserve balance is too high, please lower it down in order to turn staking on")));
+    			error = "Reserve balance is too high.\nPlease lower it in order to turn staking on.";
     			return StakingStatusError::RESERVE_TOO_HIGH;
     		}
 			if (!fMintable) {
 				if (balance > CWallet::MINIMUM_STAKE_AMOUNT) {
 					//10 is to cover transaction fees
 					if (balance >= CWallet::MINIMUM_STAKE_AMOUNT + 10*COIN) {
-						errors.push_back(QString(tr("Not enough mintable coins. Do you want to merge make a sent-to-yourself transaction to turn the wallet into stakable?.")));
+						error = "Not enough mintable coins.\nDo you want to merge & make a sent-to-yourself transaction to make the wallet stakable?";
 						return StakingStatusError::UTXO_UNDER_THRESHOLD;
 					}
 				}

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -150,7 +150,7 @@ public:
     void encryptKey(const CKey key, const std::string& pwd, const std::string& slt, std::vector<unsigned char>& crypted);
     void decryptKey(const std::vector<unsigned char>& crypted, const std::string& slt, const std::string& pwd, CKey& key);
     void emitBalanceChanged(); // Force update of UI-elements even when no values have changed
-    StakingStatusError getStakingStatusError(QStringList&);
+    StakingStatusError getStakingStatusError(QString&);
     void generateCoins(bool fGenerate, int nGenProcLimit);
 
     // Check address for validity


### PR DESCRIPTION
- Adjust capitilization, wording of many MsgBoxes
- Fix styling on Staking error message boxes
- Switch StakingStatusError to a QString (from QStringList)
- Set default window title for Staking errors to "Warning: Staking Issue"

![image](https://user-images.githubusercontent.com/2319897/64916760-fb4d9800-d751-11e9-915f-22426beacd67.png)
