### PR TITLE
DAPS-958 QT > Send: Value field, comma (,) is accepted to type but not to send

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -56,10 +56,7 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(QWidget* parent) : QDialog(parent),
         pwalletMain->CreatePrivacyAccount();
      }
 
-    QDoubleValidator *dblVal = new QDoubleValidator(0, Params().MAX_MONEY, 6, ui->reqAmount);
-    dblVal->setNotation(QDoubleValidator::StandardNotation);
-    dblVal->setLocale(QLocale::C);
-    ui->reqAmount->setValidator(dblVal);
+    ui->reqAmount->setValidator(new QRegExpValidator(QRegExp("[0-9]*.[0-9]*"), this));
 }
 
 static inline int64_t roundint64(double d)

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -44,13 +44,7 @@ SendCoinsEntry::SendCoinsEntry(QWidget* parent) : QStackedWidget(parent),
     //Cam: Hide address book button
     ui->addressBookButton->setVisible(false);
 
-    QDoubleValidator *dblVal = new QDoubleValidator(0, Params().MAX_MONEY, 6, ui->payAmount);
-    dblVal->setNotation(QDoubleValidator::StandardNotation);
-    dblVal->setLocale(QLocale::C);
-    ui->payAmount->setValidator(dblVal);
-
-
-    //place holder text for payAmount
+    ui->payAmount->setValidator(new QRegExpValidator(QRegExp("[1-9][0-9]*.[0-9]*"), this));
 }
 
 SendCoinsEntry::~SendCoinsEntry()


### PR DESCRIPTION
- Prevent comma and leading 0 in Send Amount box
- Prevent comma in Receiving Amount box