### PR TITLE
DAPS-962 Qt > 2FA: Text during disabling option do not exist

### DIFF
--- a/src/qt/forms/2faconfirmdialog.ui
+++ b/src/qt/forms/2faconfirmdialog.ui
@@ -28,7 +28,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Enter Code</string>
+        <string>Enter the 6 digit code from your authenticator app below:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>

--- a/src/qt/forms/2fadialog.ui
+++ b/src/qt/forms/2fadialog.ui
@@ -28,7 +28,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Enter Code</string>
+        <string>Enter the 6 digit code from your authenticator app below:</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignCenter</set>


### PR DESCRIPTION
- Add missing text for 2FA dialogs