### PR TITLE
DAPS 948 Qt: Sidebar icons and menu items are too close to each other

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -546,6 +546,7 @@ void BitcoinGUI::createToolBars()
 
         toolbar->setMovable(false); // remove unused icon in upper left corner
         overviewAction->setChecked(true);
+        toolbar->setStyleSheet("QToolBar{spacing:25px;}");
 
         // Create NavBar
         QToolBar* bottomToolbar = new QToolBar(this);

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -554,10 +554,12 @@ void BitcoinGUI::createToolBars()
         bottomToolbar->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
         bottomToolbar->setOrientation(Qt::Vertical);
         bottomToolbar->addAction(optionsAction);
+        bottomToolbar->addSeparator();
         bottomToolbar->addAction(stakingAction);
         bottomToolbar->addWidget(stakingState);
         bottomToolbar->addAction(networkAction);
         bottomToolbar->addWidget(connectionCount);
+        bottomToolbar->setStyleSheet("QToolBar{spacing:5px;}");
         
         bottomToolbar->setObjectName("bottomToolbar");
 


### PR DESCRIPTION
- Update tab toolbar spacing to match designs
- Update bottom toolbar spacing to match designs

![image](https://user-images.githubusercontent.com/2319897/64990717-542a4700-d89e-11e9-9090-742de365d769.png) (lines added for display only)

![image](https://user-images.githubusercontent.com/2319897/64990685-483e8500-d89e-11e9-96cb-8635cb443af9.png)
