### PR TITLE
DAPS-964 QT > Settings | Light mode influence Remember my authentication code buttons : become squeeze

### DIFF
--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -234,7 +234,7 @@ QPushButton#btn_resync{
   font-size: 15px;
 }
 
-QPushButton#btn_day, QPushButton#btn_month,QPushButton#btn_week{
+QPushButton#btn_day,QPushButton#btn_month,QPushButton#btn_week{
   min-height: 35px;
 }
 

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -234,6 +234,10 @@ QPushButton#btn_resync{
   font-size: 15px;
 }
 
+QPushButton#btn_day, QPushButton#btn_month,QPushButton#btn_week{
+  min-height: 35px;
+}
+
 QPushButton#btnLockUnlock{
   margin-right: 9px;
   width: 20px;


### PR DESCRIPTION
- Force minimum height of 2FA buttons in light theme CSS

![image](https://user-images.githubusercontent.com/2319897/64995341-f2230f00-d8a8-11e9-92f0-64c5a19ead67.png)
