### PR TITLE
QT > Staking Status Text

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1134,20 +1134,20 @@ void BitcoinGUI::setStakingStatus()
     }
 
     if (nLastCoinStakeSearchInterval || stkStatus) {
-        stakingState->setText(tr("Staking enabled"));
+        stakingState->setText(tr("Staking Enabled"));
         stakingAction->setIcon(QIcon(":/icons/staking_active"));
     } else {
-        stakingState->setText(tr("Staking disabled"));
+        stakingState->setText(tr("Staking Disabled"));
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
     }
 }
 void BitcoinGUI::setStakingInProgress(bool inProgress)
 {
 	if (inProgress) {
-        stakingState->setText(tr("Enabling staking..."));
+        stakingState->setText(tr("Enabling Staking..."));
         stakingAction->setIcon(QIcon(":/icons/staking_active"));
 	} else {
-        stakingState->setText(tr("Disabling staking..."));
+        stakingState->setText(tr("Disabling Staking..."));
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));
 	}
 }

--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -65,9 +65,9 @@ QDialog {
 }
 
 #stakingState {
-  font-size: 9px;
-  padding-left: 34px;
-  font-weight: bold;
+  font-size: 11px;
+  font-style: italic;
+  padding-left: 40px;
 }
 #connectionCount {
   font-size: 11px;

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -34,10 +34,10 @@ QComboBox:disabled,
 }
 
 #stakingState {
-  font-size: 9px;
-  padding-left: 34px;
+  font-size: 11px;
+  font-style: italic;
+  padding-left: 40px;
   color: white;
-  font-weight: bold;
 }
 #connectionCount {
   font-size: 11px;


### PR DESCRIPTION
- Make status text italic, adjust padding
- Capitalize staking statuses (to match Active Connections)

(no coins in this wallet so no Enabled screens, but here are Disabled/Disabling)

![image](https://user-images.githubusercontent.com/2319897/65167918-7395b100-da11-11e9-93eb-645bbde30354.png)

![image](https://user-images.githubusercontent.com/2319897/65167931-7bedec00-da11-11e9-9163-9ffafd76bb98.png)

Enabled
![image](https://user-images.githubusercontent.com/2319897/65170999-e6098f80-da17-11e9-9981-12391744960e.png)
