### PR TITLE
DAPS-988 QT: When locked, 'Show Phrase' should remind user to unlock as it does for 2FA

### DIFF
--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -608,6 +608,16 @@ void OptionsPage::on_month() {
 }
 
 void OptionsPage::onShowMnemonic() {
+    int status = model->getEncryptionStatus();
+    if (status == WalletModel::Locked || status == WalletModel::UnlockedForAnonymizationOnly) {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Mnemonic Recovery Phrase");
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setText("Please unlock the keychain wallet with your passphrase before attempting to view your Mnemonic Recovery Phrase.");
+        msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
+        msgBox.exec();
+        return;
+    }
     CHDChain hdChainCurrent;
     if (!pwalletMain->GetDecryptedHDChain(hdChainCurrent))
         return;


### PR DESCRIPTION
- Check if unlocked before displaying Mnemonic Recovery Phrase

![image](https://user-images.githubusercontent.com/2319897/65274460-56d0aa80-daf1-11e9-8aaf-e4bbefbc5758.png)
