### PR TITLE
DAPS-938 Qt Multisig: Overview: Recent Transactions list items are not visible at first startup

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -423,7 +423,6 @@ int OverviewPage::tryNetworkBlockCount(){
 }
 
 void OverviewPage::updateRecentTransactions(){
-	if (isSyncingBlocks) return;
 	if (!pwalletMain || pwalletMain->IsLocked()) return;
     QLayoutItem* item;
     QSettings settings;


### PR DESCRIPTION
- Remove isSyncingBlocks from updateRecentTransactions()

This was causing the function to return as pretty much every time after launch and entering your passphrase there will be some syncing required. The locked check still remains in tact.