### PR TITLE
Codefresh: Remove #include <execinfo.h>

### DIFF
--- a/src/qt/dapscoin.cpp
+++ b/src/qt/dapscoin.cpp
@@ -44,7 +44,6 @@
 #include "unlockdialog.h"
 
 #include <stdint.h>
-#include <execinfo.h>
 #include <signal.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Fixes

qt/dapscoin.cpp:47:10: fatal error: execinfo.h: No such file or directory                                                                
 #include <execinfo.h>                                                                                                                   
          ^~~~~~~~~~~~                                                                                                                   
compilation terminated.