### PR TITLE
DAPS-999 Qt: Hover Tooltips are not DAPS colors

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -116,6 +116,7 @@ BitcoinGUI::BitcoinGUI(const NetworkStyle* networkStyle, QWidget* parent) : QMai
 {
     /* Open CSS when configured */
     this->setStyleSheet(GUIUtil::loadStyleSheet());
+    qApp->setStyleSheet("QToolTip { color: white; background-color: #5E1C5A; border: 1px solid white; border-radius:5px; }");
 
     this->setMinimumSize(1180, 790);
     GUIUtil::restoreWindowGeometry("nWindow", QSize(1180, 790), this);


### PR DESCRIPTION
- Set tooltips to DAPS colors and rounded

For some reason it was not working in Dark.css and Light.css. This achieves the same.

![image](https://user-images.githubusercontent.com/2319897/65397307-184f2000-dd7d-11e9-9ab1-e3a080f2d499.png)
