### PR TITLE
QT > Recent Transactions fix

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -486,7 +486,6 @@ void OverviewPage::updateRecentTransactions(){
 }
 
 void OverviewPage::refreshRecentTransactions() {
-	if (isSyncingBlocks) return;
 	updateRecentTransactions();
 }
 


### PR DESCRIPTION
- Remove if (isSyncingBlocks) return; so Recent Transactions list will update while syncing

Similar to to #488, but in a different function

This was causing the function to return as pretty much every time after launch and entering your passphrase there will be some syncing required. The locked check still remains in tact.