### PR TITLE
Fix filename from "Core" removal

### DIFF
--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -112,7 +112,7 @@ RUN cd /DAPS/ && mkdir -p /BUILD/ && \
         make HOST="x86_64-apple-darwin11" -j2 && \
         make deploy && \
         make install HOST="x86_64-apple-darwin11" DESTDIR=/BUILD/ && \
-        mv Dapscoin-Core.dmg DAPScoin-Qt.dmg && \
+        mv Dapscoin.dmg DAPScoin-Qt.dmg && \
         cp DAPScoin-Qt.dmg /BUILD/bin/; \
 #
     else echo "Build target not recognized."; \

--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -112,7 +112,7 @@ RUN cd /DAPS/ && mkdir -p /BUILD/ && \
         make HOST="x86_64-apple-darwin11" -j2 && \
         make deploy && \
         make install HOST="x86_64-apple-darwin11" DESTDIR=/BUILD/ && \
-        mv Dapscoin.dmg DAPScoin-Qt.dmg && \
+        mv DAPScoin.dmg DAPScoin-Qt.dmg && \
         cp DAPScoin-Qt.dmg /BUILD/bin/; \
 #
     else echo "Build target not recognized."; \


### PR DESCRIPTION
Looks like one of the recent changes to removing "Core" has resulted in the Mac Filename changing.
This fixes the error on Codefresh.

`mv: cannot stat 'Dapscoin-Core.dmg': No such file or directory   `