### PR TITLE
DAPS-995 QT > Multisig: Add Co-signer text area is too dark

### DIFF
--- a/src/qt/forms/multisigsetupaddsigner.ui
+++ b/src/qt/forms/multisigsetupaddsigner.ui
@@ -51,7 +51,11 @@ and private view key. Send this combo key to your n co-signers</string>
     </widget>
    </item>
    <item>
-    <widget class="QTextEdit" name="textComboKey"/>
+    <widget class="QTextEdit" name="textComboKey">
+     <property name="acceptRichText">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_5">


### PR DESCRIPTION
Issue has changed and is actually related to pasting keeping the formatting of text from where it was copied from.
This should prevent that.