### PR TITLE
DAPS-948 Qt Multisig: Sidebar icons and their respective menu items are too close to one another

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -268,6 +268,7 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
     QActionGroup* tabGroup = new QActionGroup(this);
 
     overviewAction = new QAction(QIcon(":/icons/overview"), tr("&Overview"), this);
+    overviewAction->setIconText("    &Overview");
     overviewAction->setStatusTip(QString());
     overviewAction->setToolTip(QString());
     overviewAction->setCheckable(true);
@@ -278,8 +279,8 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
 #endif
     tabGroup->addAction(overviewAction);
 
-    sendCoinsAction = new QAction(QIcon(":/icons/send"), tr("&   Create\nTransaction"), this);
-
+    sendCoinsAction = new QAction(QIcon(":/icons/send"), tr("&Create\nTransaction"), this);
+    sendCoinsAction->setIconText("    &Create\n    Transaction");
     sendCoinsAction->setToolTip("Create Transaction");
     sendCoinsAction->setCheckable(true);
 #ifdef Q_OS_MAC
@@ -289,7 +290,8 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
 #endif
     tabGroup->addAction(sendCoinsAction);
 
-    cosignAction = new QAction(QIcon(":/icons/send"), tr("&   Co-Sign\nTransaction"), this);
+    cosignAction = new QAction(QIcon(":/icons/send"), tr("&Co-Sign\nTransaction"), this);
+    cosignAction->setIconText("    &Co-Sign\n    Transaction");
     cosignAction->setToolTip("Co-Sign Transaction");
     cosignAction->setCheckable(true);
 #ifdef Q_OS_MAC
@@ -300,6 +302,7 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
     tabGroup->addAction(cosignAction);
 
     keyImageSyncAction = new QAction(QIcon(":/icons/send"), tr("&   Sync\nKeyImage"), this);
+    keyImageSyncAction->setIconText("    &Sync\n    KeyImage");
     keyImageSyncAction->setToolTip("Sync KeyImage");
     keyImageSyncAction->setCheckable(true);
 #ifdef Q_OS_MAC
@@ -309,7 +312,8 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
 #endif
     tabGroup->addAction(keyImageSyncAction);
 
-    receiveCoinsAction = new QAction(QIcon(":/icons/receiving_addresses"), tr("&   Receive"), this);
+    receiveCoinsAction = new QAction(QIcon(":/icons/receiving_addresses"), tr("&Receive"), this);
+    receiveCoinsAction->setIconText("    &Receive");
     receiveCoinsAction->setToolTip(QString());
     receiveCoinsAction->setCheckable(true);
 #ifdef Q_OS_MAC
@@ -319,7 +323,8 @@ void BitcoinGUI::createActions(const NetworkStyle* networkStyle)
 #endif
     tabGroup->addAction(receiveCoinsAction);
 
-    historyAction = new QAction(QIcon(":/icons/history"), tr("&   History"), this);
+    historyAction = new QAction(QIcon(":/icons/history"), tr("&History"), this);
+    historyAction->setIconText("    &History");
     historyAction->setToolTip(QString());
     historyAction->setCheckable(true);
 #ifdef Q_OS_MAC

--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -67,12 +67,12 @@ QDialog {
 #stakingState {
   font-size: 11px;
   font-style: italic;
-  padding-left: 40px;
+  padding-left: 60px;
 }
 #connectionCount {
   font-size: 11px;
   font-style: italic;
-  padding-left: 32px;
+  padding-left: 52px;
 }
 
 QDialog .QTabWidget QTabBar::tab {

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -36,13 +36,13 @@ QComboBox:disabled,
 #stakingState {
   font-size: 11px;
   font-style: italic;
-  padding-left: 40px;
+  padding-left: 60px;
   color: white;
 }
 #connectionCount {
   font-size: 11px;
   font-style: italic;
-  padding-left: 32px;
+  padding-left: 52px;
   color: white;
 }
 


### PR DESCRIPTION
- Add spacing to sidebar items
![image](https://user-images.githubusercontent.com/2319897/65793447-d8e55280-e133-11e9-9152-eb7ae300966b.png)
