### PR TITLE
DAPS-962 Qt > 2FA: Text during disabling option do not exist

### DIFF
--- a/src/qt/2fadialog.cpp
+++ b/src/qt/2fadialog.cpp
@@ -52,8 +52,9 @@ TwoFADialog::TwoFADialog(QWidget *parent) :
 
     ui->lblOpenAppURL->setVisible(false);
     bool status = pwalletMain->Read2FA();
-    if (!status) {
-        ui->label_2->setVisible(true);
+    if (status) {
+        ui->label_2->setVisible(false);
+        ui->label->setText("Disabling 2 Factor Authentication");
     }
 }
 

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -491,7 +491,7 @@ void OptionsPage::on_Enable2FA(ToggleButton* widget)
     } else {
         typeOf2FA = DISABLE;
 
-        TwoFAConfirmDialog codedlg;
+        TwoFADialog codedlg;
         codedlg.setWindowTitle("2FA Code Verification");
         codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
         connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
@@ -637,7 +637,7 @@ void OptionsPage::confirmDialogIsFinished(int result) {
 void OptionsPage::on_day() {
     typeOf2FA = DAY;
 
-    TwoFAConfirmDialog codedlg;
+    TwoFADialog codedlg;
     codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
@@ -647,7 +647,7 @@ void OptionsPage::on_day() {
 void OptionsPage::on_week() {
     typeOf2FA = WEEK;
 
-    TwoFAConfirmDialog codedlg;
+    TwoFADialog codedlg;
     codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
@@ -657,7 +657,7 @@ void OptionsPage::on_week() {
 void OptionsPage::on_month() {
     typeOf2FA = MONTH;
 
-    TwoFAConfirmDialog codedlg;
+    TwoFADialog codedlg;
     codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -492,7 +492,7 @@ void OptionsPage::on_Enable2FA(ToggleButton* widget)
         typeOf2FA = DISABLE;
 
         TwoFAConfirmDialog codedlg;
-        codedlg.setWindowTitle("2FACode Verification");
+        codedlg.setWindowTitle("2FA Code Verification");
         codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
         connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
         codedlg.exec();
@@ -502,7 +502,7 @@ void OptionsPage::on_Enable2FA(ToggleButton* widget)
 void OptionsPage::qrDialogIsFinished(int result) {
     if(result == QDialog::Accepted){
         TwoFADialog codedlg;
-        codedlg.setWindowTitle("2FACode Verification");
+        codedlg.setWindowTitle("2FA Code Verification");
         codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
         connect(&codedlg, SIGNAL(finished (int)), this, SLOT(dialogIsFinished(int)));
         codedlg.exec();
@@ -638,7 +638,7 @@ void OptionsPage::on_day() {
     typeOf2FA = DAY;
 
     TwoFAConfirmDialog codedlg;
-    codedlg.setWindowTitle("2FACode Verification");
+    codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
     codedlg.exec();
@@ -648,7 +648,7 @@ void OptionsPage::on_week() {
     typeOf2FA = WEEK;
 
     TwoFAConfirmDialog codedlg;
-    codedlg.setWindowTitle("2FACode Verification");
+    codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
     codedlg.exec();   
@@ -658,7 +658,7 @@ void OptionsPage::on_month() {
     typeOf2FA = MONTH;
 
     TwoFAConfirmDialog codedlg;
-    codedlg.setWindowTitle("2FACode Verification");
+    codedlg.setWindowTitle("2FA Code Verification");
     codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
     connect(&codedlg, SIGNAL(finished (int)), this, SLOT(confirmDialogIsFinished(int)));
     codedlg.exec();

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -153,7 +153,7 @@ void SendCoinsDialog::on_sendButton_clicked(){
         sendTx();
     else {
         TwoFAConfirmDialog codedlg;
-        codedlg.setWindowTitle("2FACode Verification");
+        codedlg.setWindowTitle("2FA Code Verification");
         codedlg.setStyleSheet(GUIUtil::loadStyleSheet());
         connect(&codedlg, SIGNAL(finished (int)), this, SLOT(dialogIsFinished(int)));
         codedlg.exec();


### PR DESCRIPTION
Enabling:
![image](https://user-images.githubusercontent.com/2319897/65811527-c5fc6d80-e187-11e9-9a0c-c18ad21ee555.png)

Disabling:
![image](https://user-images.githubusercontent.com/2319897/65811523-b5e48e00-e187-11e9-8f0e-dba147e2daa5.png)
