### PR TITLE
DAPS-761 From PIVX Upstream: Db runtime error cleaning the variable that needs to be logged

### DIFF
--- a/src/db.cpp
+++ b/src/db.cpp
@@ -260,8 +260,9 @@ CDB::CDB(const std::string& strFilename, const char* pszMode) : pdb(NULL), activ
                 delete pdb;
                 pdb = NULL;
                 --bitdb.mapFileUseCount[strFile];
+                std::string tempCopy(strFile);
                 strFile = "";
-                throw runtime_error(strprintf("CDB : Error %d, can't open database %s", ret, strFile));
+                throw std::runtime_error(strprintf("CDB : Error %d, can't open database %s", ret, tempCopy));
             }
 
             if (fCreate && !Exists(string("version"))) {


### PR DESCRIPTION
"Straightforward change, the variable is been cleaned before the logging. Temp variable copy to be able to print it."

Could be useful for future logging

from: https://github.com/PIVX-Project/PIVX/pull/989