### PR TITLE
DAPS-1338 From PIVX Upstream: Ensure that a numeric is being passed to AmountFromValue

### DIFF
--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -108,6 +108,9 @@ static inline int64_t roundint64(double d) {
 }
 
 CAmount AmountFromValue(const UniValue& value) {
+    if (!value.isNum())
+        throw JSONRPCError(RPC_TYPE_ERROR, "Amount is not a number");
+
     double dAmount = value.get_real();
     if (dAmount <= 0.0 || dAmount > Params().MAX_MONEY)
         throw JSONRPCError(RPC_TYPE_ERROR, "Invalid amount");


### PR DESCRIPTION
"Return a more descriptive type error when the input paramater is not a
numeric.

This clarifies the response message a bit and allows for a faster exit
response by not needing to do subsequent mathematical or external
function checks.

NOTE: This isn't a functional change, since non-numeric input values
would previously fail anyways, returning only an "Invalid amount" error
message."

from: https://github.com/PIVX-Project/PIVX/pull/724