### PR TITLE
DAPS-761 From PIVX: Remove deprecated throw() build warnings in leveldb function signatures

### DIFF
--- a/src/leveldbwrapper.cpp
+++ b/src/leveldbwrapper.cpp
@@ -13,7 +13,7 @@
 #include <leveldb/filter_policy.h>
 #include <memenv.h>
 
-void HandleError(const leveldb::Status& status) throw(leveldb_error)
+void HandleError(const leveldb::Status& status)
 {
     if (status.ok())
         return;
@@ -80,7 +80,7 @@ CLevelDBWrapper::~CLevelDBWrapper()
     options.env = NULL;
 }
 
-bool CLevelDBWrapper::WriteBatch(CLevelDBBatch& batch, bool fSync) throw(leveldb_error)
+bool CLevelDBWrapper::WriteBatch(CLevelDBBatch& batch, bool fSync)
 {
     leveldb::Status status = pdb->Write(fSync ? syncoptions : writeoptions, &batch.batch);
     HandleError(status);

--- a/src/leveldbwrapper.h
+++ b/src/leveldbwrapper.h
@@ -22,7 +22,7 @@ public:
     leveldb_error(const std::string& msg) : std::runtime_error(msg) {}
 };
 
-void HandleError(const leveldb::Status& status) throw(leveldb_error);
+void HandleError(const leveldb::Status& status);
 
 /** Batch of changes queued to be written to a CLevelDBWrapper */
 class CLevelDBBatch
@@ -90,7 +90,7 @@ public:
     ~CLevelDBWrapper();
 
     template <typename K, typename V>
-    bool Read(const K& key, V& value) const throw(leveldb_error)
+    bool Read(const K& key, V& value) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -115,7 +115,7 @@ public:
     }
 
     template <typename K, typename V>
-    bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error)
+    bool Write(const K& key, const V& value, bool fSync = false)
     {
         CLevelDBBatch batch;
         batch.Write(key, value);
@@ -123,7 +123,7 @@ public:
     }
 
     template <typename K>
-    bool Exists(const K& key) const throw(leveldb_error)
+    bool Exists(const K& key) const
     {
         CDataStream ssKey(SER_DISK, CLIENT_VERSION);
         ssKey.reserve(ssKey.GetSerializeSize(key));
@@ -142,14 +142,14 @@ public:
     }
 
     template <typename K>
-    bool Erase(const K& key, bool fSync = false) throw(leveldb_error)
+    bool Erase(const K& key, bool fSync = false)
     {
         CLevelDBBatch batch;
         batch.Erase(key);
         return WriteBatch(batch, fSync);
     }
 
-    bool WriteBatch(CLevelDBBatch& batch, bool fSync = false) throw(leveldb_error);
+    bool WriteBatch(CLevelDBBatch& batch, bool fSync = false);
 
     // not available for LevelDB; provide for compatibility with BDB
     bool Flush()
@@ -157,7 +157,7 @@ public:
         return true;
     }
 
-    bool Sync() throw(leveldb_error)
+    bool Sync()
     {
         CLevelDBBatch batch;
         return WriteBatch(batch, true);


### PR DESCRIPTION
This one just gets rid of a bunch of warnings for a cleaner build log. No functional changes.

"Using throw() specifications in function signatures is not only not required in C++, it is considered deprecated for [various reasons] https://stackoverflow.com/questions/1055387/throw-keyword-in-functions-signature).
It is not implemented by any of the common C++ compilers. The usage is
also inconsistent with the rest of the source code."

From: https://github.com/PIVX-Project/PIVX/pull/706

Removes these warnings:
`In file included from ./txdb.h:11:0,
                 from qt/optionsmodel.cpp:21:
./leveldbwrapper.h:25:49: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 void HandleError(const leveldb::Status& status) throw(leveldb_error);
                                                 ^~~~~
./leveldbwrapper.h:93:45: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Read(const K& key, V& value) const throw(leveldb_error)
                                             ^~~~~
./leveldbwrapper.h:118:66: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error)
                                                                  ^~~~~
./leveldbwrapper.h:126:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Exists(const K& key) const throw(leveldb_error)
                                     ^~~~~
./leveldbwrapper.h:145:50: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Erase(const K& key, bool fSync = false) throw(leveldb_error)
                                                  ^~~~~
./leveldbwrapper.h:152:63: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool WriteBatch(CLevelDBBatch& batch, bool fSync = false) throw(leveldb_error);
                                                               ^~~~~
./leveldbwrapper.h:160:17: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Sync() throw(leveldb_error)
                 ^~~~~
  CXX      qt/qt_libbitcoinqt_a-2faconfirmdialog.o
In file included from ./txdb.h:11:0,
                 from qt/optionsdialog.cpp:19:
./leveldbwrapper.h:25:49: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
 void HandleError(const leveldb::Status& status) throw(leveldb_error);
                                                 ^~~~~
./leveldbwrapper.h:93:45: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Read(const K& key, V& value) const throw(leveldb_error)
                                             ^~~~~
./leveldbwrapper.h:118:66: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Write(const K& key, const V& value, bool fSync = false) throw(leveldb_error)
                                                                  ^~~~~
./leveldbwrapper.h:126:37: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Exists(const K& key) const throw(leveldb_error)
                                     ^~~~~
./leveldbwrapper.h:145:50: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Erase(const K& key, bool fSync = false) throw(leveldb_error)
                                                  ^~~~~
./leveldbwrapper.h:152:63: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool WriteBatch(CLevelDBBatch& batch, bool fSync = false) throw(leveldb_error);
                                                               ^~~~~
./leveldbwrapper.h:160:17: warning: dynamic exception specifications are deprecated in C++11 [-Wdeprecated]
     bool Sync() throw(leveldb_error)
                 ^~~~~
`