### PR TITLE
DAPS-1095 QT: Allow user to choose backup location

### DIFF
--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -312,11 +312,18 @@ void OptionsPage::on_pushButtonPasswordClear_clicked()
 }
 
 void OptionsPage::on_pushButtonBackup_clicked(){
-    if (model->backupWallet(QString("BackupWallet.dat"))) {
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Backup Wallet"), QString(),
+        tr("Wallet Data (*.dat)"), NULL);
+
+    if (filename.isEmpty())
+        return;
+
+    if (model->backupWallet(QString(filename))) {
         ui->pushButtonBackup->setStyleSheet("border: 2px solid green");
         QMessageBox msgBox;
         msgBox.setWindowTitle("Wallet Backup Successful");
-        msgBox.setText("Wallet has been successfully backed up to BackupWallet.dat in " + qApp->applicationDirPath());
+        msgBox.setText("Wallet has been successfully backed up to " + filename);
         msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
         msgBox.setIcon(QMessageBox::Information);
         msgBox.exec();

--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -327,7 +327,8 @@ void OptionsPage::on_pushButtonBackup_clicked(){
         msgBox.setStyleSheet(GUIUtil::loadStyleSheet());
         msgBox.setIcon(QMessageBox::Information);
         msgBox.exec();
-    } else { ui->pushButtonBackup->setStyleSheet("border: 2px solid red");
+    } else {
+        ui->pushButtonBackup->setStyleSheet("border: 2px solid red");
         QMessageBox msgBox;
         msgBox.setWindowTitle("Wallet Backup Failed");
         msgBox.setText("Wallet backup failed. Please try again.");


### PR DESCRIPTION
- Allow user to choose backup location
(Re-uses code from previous Backup Wallet action)

![image](https://user-images.githubusercontent.com/2319897/66347845-4018b900-e923-11e9-8f4c-529aeded9d42.png)

![image](https://user-images.githubusercontent.com/2319897/66347855-4444d680-e923-11e9-9694-a341feebaabf.png)

This should also fix DAPS-1095 QT: Mac's Backup Wallet function does not appear to work like Lin and Win do