### PR TITLE
DAPS-1337 From PIVX: [Net] nLastTry is only used for addrman entries

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -336,10 +336,10 @@ void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
     info.nAttempts++;
 }
 
-CAddress CAddrMan::Select_()
+CAddrInfo CAddrMan::Select_()
 {
     if (size() == 0)
-        return CAddress();
+        return CAddrInfo();
 
     // Use a 50% chance for choosing between tried and new table entries.
     if (nTried > 0 && (nNew == 0 || GetRandInt(2) == 0)) {

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -22,15 +22,16 @@
  */
 class CAddrInfo : public CAddress
 {
+public:
+    //! last try whatsoever by us (memory only)
+    int64_t nLastTry;
+
 private:
     //! where knowledge about this address first came from
     CNetAddr source;
 
     //! last successful connection by us
     int64_t nLastSuccess;
-
-    //! last try whatsoever by us:
-    // int64_t CAddress::nLastTry
 
     //! connection attempts since last successful attempt
     int nAttempts;
@@ -229,7 +230,7 @@ protected:
 
     //! Select an address to connect to.
     //! nUnkBias determines how much to favor new addresses over tried ones (min=0, max=100)
-    CAddress Select_();
+    CAddrInfo Select_();
 
 #ifdef DEBUG_ADDRMAN
     //! Perform consistency check. Returns an error code or zero.
@@ -531,9 +532,9 @@ public:
      * Choose an address to connect to.
      * nUnkBias determines how much "new" entries are favored over "tried" ones (0-100).
      */
-    CAddress Select()
+    CAddrInfo Select()
     {
-        CAddress addrRet;
+        CAddrInfo addrRet;
         {
             LOCK(cs);
             Check();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1334,7 +1334,7 @@ void ThreadOpenConnections() {
 
         int nTries = 0;
         while (true) {
-            CAddress addr = addrman.Select();
+            CAddrInfo addr = addrman.Select();
 
             // if we selected an invalid address, restart
             if (!addr.IsValid() || setConnected.count(addr.GetGroup()) || IsLocal(addr))

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -96,7 +96,6 @@ void CAddress::Init()
 {
     nServices = NODE_NETWORK;
     nTime = 100000000;
-    nLastTry = 0;
 }
 
 CInv::CInv()

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -117,9 +117,6 @@ public:
 
     // disk and network only
     unsigned int nTime;
-
-    // memory only
-    int64_t nLastTry;
 };
 
 /** inv message data */


### PR DESCRIPTION
No need to define it for every CAddress, as it's memory only anyway.

https://github.com/PIVX-Project/PIVX/pull/800