### PR TITLE
DAPS-1305 from PIVX: Improve addrman Select() performance when buckets are nearly empty

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -365,8 +365,10 @@ CAddress CAddrMan::Select_()
         while (1) {
             int nUBucket = GetRandInt(ADDRMAN_NEW_BUCKET_COUNT);
             int nUBucketPos = GetRandInt(ADDRMAN_BUCKET_SIZE);
-            if (vvNew[nUBucket][nUBucketPos] == -1)
-                continue;
+            while (vvNew[nUBucket][nUBucketPos] == -1) {
+                nUBucket = (nUBucket + insecure_rand()) % ADDRMAN_NEW_BUCKET_COUNT;
+                nUBucketPos = (nUBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+            }
             int nId = vvNew[nUBucket][nUBucketPos];
             assert(mapInfo.count(nId) == 1);
             CAddrInfo& info = mapInfo[nId];


### PR DESCRIPTION
Simple backport of bitcoin#6530

https://github.com/PIVX-Project/PIVX/pull/798

Earlier, when there are only a few entries in the addrman tables, Select() could spin for long periods of time (~200ms), resulting in high CPU usage (up to 40% here). This reduces it to around 0.3ms (0.5% CPU).

(We have half of this commit for some reason, second half added)