### PR TITLE
DAPS-761 From PIVX: Remove Redundant Declarations that cause compiler warnings

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -175,15 +175,6 @@ extern CBlockIndex* pindexBestHeader;
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
 
-/** Register a wallet to receive updates from core */
-void RegisterValidationInterface(CValidationInterface* pwalletIn);
-/** Unregister a wallet from core */
-void UnregisterValidationInterface(CValidationInterface* pwalletIn);
-/** Unregister all wallets from core */
-void UnregisterAllValidationInterfaces();
-/** Push an updated transaction to all registered wallets */
-void SyncWithWallets(const CTransaction& tx, const CBlock* pblock = NULL);
-
 /** Register with a network node to receive its signals */
 void RegisterNodeSignals(CNodeSignals& nodeSignals);
 /** Unregister a network node */
@@ -240,10 +231,6 @@ bool SendMessages(CNode* pto, bool fSendTrickle);
 /** Run an instance of the script checking thread */
 void ThreadScriptCheck();
 
-// ***TODO*** probably not the right place for these 2
-/** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
-bool CheckProofOfWork(uint256 hash, unsigned int nBits);
-
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core */
@@ -253,8 +240,6 @@ bool GetTransaction(const uint256& hash, CTransaction& tx, uint256& hashBlock, b
 /** Find the best known block, and make it the tip of the block chain */
 
 bool CheckHaveInputs(const CCoinsViewCache& view, const CTransaction& tx);
-
-bool DisconnectBlocksAndReprocess(int blocks);
 
 // ***TODO***
 double ConvertBitsToDouble(unsigned int nBits);


### PR DESCRIPTION
"Noticed some redundant function declarations in main.h that were throwing compiler warnings."

https://github.com/PIVX-Project/PIVX/pull/697