### PR TITLE
DAPS-1218 Qt: Fix banning of other peers while syncing, but not yet fully synced

### DIFF
--- a/src/masternode-sync.cpp
+++ b/src/masternode-sync.cpp
@@ -41,16 +41,6 @@ bool CMasternodeSync::IsBlockchainSynced()
     }
     lastProcess = GetTime();
 
-    if (!fBlockchainSynced && vNodes.size() >= 1){
-    	int highestCount = 0;
-    	for (CNode* node : vNodes)
-    		if (node->nStartingHeight>highestCount)
-    			highestCount = node->nStartingHeight;
-    	if (highestCount <= chainActive.Height()) {
-    		fBlockchainSynced = true;
-    	}
-    }
-
     if (fBlockchainSynced) return true;
 
     if (fImporting || fReindex) return false;

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -17,6 +17,7 @@
 #include <math.h>
 
 unsigned int N_BITS = 0x1e1ffff0;
+unsigned int N_BITS_SF = 0x1e050000;
 bool CheckPoAMiningBlockHeight(const CBlockHeader* pblock)
 {
     return false;
@@ -25,7 +26,10 @@ bool CheckPoAMiningBlockHeight(const CBlockHeader* pblock)
 unsigned int GetNextWorkRequired(const CBlockIndex* pindexLast, const CBlockHeader* pblock)
 {
     if (N_BITS != 0 && pblock->IsPoABlockByVersion()) {
-        return N_BITS;
+        if (pindexLast->nHeight < 30400) {
+            return N_BITS;
+        }
+        return N_BITS_SF;
     }
     /* current difficulty formula, dapscoin - DarkGravity v3, written by Evan Duffield - evan@dashpay.io */
     const CBlockIndex* BlockLastSolved = pindexLast;


### PR DESCRIPTION
Removes the false assertion in masternode-sync.cpp that claims full sync when it may not yet be true.