### PR TITLE
DAPS-1078 Qt > Overview: The Syncing vs. Synced circles are missing the '(Synced)" text when syncing finishes

### DIFF
--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -311,14 +311,20 @@ void OverviewPage::showBalanceSync(bool fShow){
 
 void OverviewPage::showBlockSync(bool fShow)
 {
-    ui->labelBlockStatus->setVisible(fShow);
+    ui->labelBlockStatus->setVisible(true);
     ui->labelBlockOf->setVisible(fShow);
     ui->labelBlocksTotal->setVisible(fShow);
 
     isSyncingBlocks = fShow;
 
     ui->labelBlockCurrent->setText(QString::number(clientModel->getNumBlocks()));
-    ui->labelBlockCurrent->setAlignment(fShow? (Qt::AlignRight|Qt::AlignVCenter):(Qt::AlignHCenter|Qt::AlignTop));
+    if (isSyncingBlocks){
+        ui->labelBlockStatus->setText("(syncing)");
+        ui->labelBlockCurrent->setAlignment((Qt::AlignRight|Qt::AlignVCenter));
+    } else {
+        ui->labelBlockStatus->setText("(synced)");
+        ui->labelBlockCurrent->setAlignment((Qt::AlignHCenter|Qt::AlignVCenter));
+    }
 }
 
 void OverviewPage::showBlockCurrentHeight()


### PR DESCRIPTION
- Show (syncing) vs (synced) in Blocks circle

syncing as expected
![image](https://user-images.githubusercontent.com/2319897/67531701-b3dff300-f691-11e9-8218-943e53c1b955.png)

synced
![image](https://user-images.githubusercontent.com/2319897/67531694-adea1200-f691-11e9-8453-04e4b5bb1e12.png)
