### PR TITLE
DAPS-1249 QT > settings | move "Repeat new passphrase" to as bottom text box in change current passphrase

### DIFF
--- a/src/qt/forms/optionspage.ui
+++ b/src/qt/forms/optionspage.ui
@@ -98,8 +98,6 @@
                <verstretch>0</verstretch>
               </sizepolicy>
              </property>
-             <property name="toolTip">
-             </property>
              <property name="layoutDirection">
               <enum>Qt::RightToLeft</enum>
              </property>
@@ -198,16 +196,6 @@
           </widget>
          </item>
          <item>
-          <widget class="QLineEdit" name="lineEditNewPassRepeat">
-           <property name="echoMode">
-            <enum>QLineEdit::Password</enum>
-           </property>
-           <property name="placeholderText">
-            <string>Repeat new passphrase</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QLineEdit" name="lineEditOldPass">
            <property name="echoMode">
             <enum>QLineEdit::Password</enum>
@@ -224,6 +212,16 @@
            </property>
            <property name="placeholderText">
             <string>New passphrase</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="lineEditNewPassRepeat">
+           <property name="echoMode">
+            <enum>QLineEdit::Password</enum>
+           </property>
+           <property name="placeholderText">
+            <string>Repeat new passphrase</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Somehow these got swapped, likely when I re-arranged the Settings screen

![image](https://user-images.githubusercontent.com/2319897/67608667-4bf3e000-f757-11e9-9b05-9a1ccfde66e7.png)

This fixes the order