### PR TITLE
DAPS-1134 - QT > send more than 2.1B will crash wallet

### DIFF
--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -98,7 +98,7 @@ void SendCoinsDialog::on_sendButton_clicked(){
     SendCoinsRecipient recipient = form->getValue();
     QString address = recipient.address;
     bool isValidAddresss = (regex_match(address.toStdString(), regex("[a-zA-z0-9]+")))&&(address.length()==99||address.length()==110);
-    bool isValidAmount = ((recipient.amount>0) && (recipient.amount<=model->getBalance()));
+    bool isValidAmount = ((recipient.amount>0) && (recipient.amount<2100000000));
 
     form->errorAddress(isValidAddresss);
     form->errorAmount(isValidAmount);


### PR DESCRIPTION
isValidAmount was checking for greater than 0 and greater than balance.

I have split this up isValidAmount - checks for valid amount between 0 and 2.1b
and
isAvailableAmount - checks for Available balance, producing a different error message if the amount is greater than their balance

![image](https://user-images.githubusercontent.com/2319897/67647389-8b156300-f908-11e9-80da-65998c3c1c6f.png)
