### PR TITLE
DAPS-1152 fix wallet crash issue if tools windows is open

### DIFF
--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -70,7 +70,7 @@ public:
 #endif // ENABLE_WALLET
     bool enableWallet;
     bool fMultiSend = false;
-
+    RPCConsole* rpcConsole;
 
 protected:
     void changeEvent(QEvent* e);
@@ -133,7 +133,6 @@ private:
     QSystemTrayIcon* trayIcon;
     QMenu* trayIconMenu;
     Notificator* notificator;
-    RPCConsole* rpcConsole;
     BlockExplorer* explorerWindow;
     bool showTooltips = false;
 

--- a/src/qt/dapscoin.cpp
+++ b/src/qt/dapscoin.cpp
@@ -454,6 +454,8 @@ void BitcoinApplication::requestShutdown()
 {
     qDebug() << __func__ << ": Requesting shutdown";
     startThread();
+    if (window->rpcConsole)
+        delete window->rpcConsole;
     window->hide();
     window->setClientModel(0);
     pollShutdownTimer->stop();


### PR DESCRIPTION
fix wallet crash issue if tools windows is open