### PR TITLE
DAPS-1057: Qt: Manually locking may not always stop staking

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1092,7 +1092,7 @@ void BitcoinGUI::setStakingStatus()
         stkStatus = pwalletMain->ReadStakingStatus();
     }
 
-    if (!stkStatus) {
+    if (!stkStatus || pwalletMain->stakingMode == StakingMode::STOPPED) {
         stakingState->setText(tr("Staking Disabled"));
         stakingState->setToolTip("Staking Disabled");
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -531,6 +531,7 @@ void OverviewPage::unlockDialogIsFinished(int result) {
         ui->labelBalance_2->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, walletModel->getBalance(), false, BitcoinUnits::separatorAlways));
         ui->labelBalance->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, walletModel->getSpendableBalance(), false, BitcoinUnits::separatorAlways));
         ui->labelUnconfirmed->setText(BitcoinUnits::floorHtmlWithUnit(nDisplayUnit, walletModel->getUnconfirmedBalance(), false, BitcoinUnits::separatorAlways));
+        pwalletMain->stakingMode = StakingMode::STAKING_WITH_CONSOLIDATION;
     }
 }
 
@@ -540,6 +541,7 @@ void OverviewPage::lockDialogIsFinished(int result) {
         ui->labelBalance_2->setText("Locked; Hidden");
         ui->labelBalance->setText("Locked; Hidden");
         ui->labelUnconfirmed->setText("Locked; Hidden");
+        pwalletMain->stakingMode = StakingMode::STOPPED;
     }
 }
 

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -115,8 +115,13 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
         nStaking = true;
     else if (mapHashedBlocks.count(chainActive.Tip()->nHeight - 1) && nLastCoinStakeSearchInterval)
         nStaking = true;
-    obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-    obj.push_back(Pair("staking status", (nStaking ? "active" : "inactive")));
+    if (pwalletMain->IsLocked()) {
+        obj.push_back(Pair("staking mode", ("disabled")));
+        obj.push_back(Pair("staking status", ("inactive")));
+    } else {
+        obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
+        obj.push_back(Pair("staking status", (nStaking ? "active" : "inactive")));
+    }
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
     return obj;
 }
@@ -502,9 +507,13 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         nStaking = true;
     else if (mapHashedBlocks.count(chainActive.Tip()->nHeight - 1) && nLastCoinStakeSearchInterval)
         nStaking = true;
-    obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-    obj.push_back(Pair("staking status", (nStaking ? "active" : "inactive")));
-
+    if (pwalletMain->IsLocked()) {
+        obj.push_back(Pair("staking mode", ("disabled")));
+        obj.push_back(Pair("staking status", ("inactive")));
+    } else {
+        obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
+        obj.push_back(Pair("staking status", (nStaking ? "active" : "inactive")));
+    }
     return obj;
 }
 #endif // ENABLE_WALLET


### PR DESCRIPTION
- Show "Staking Disabled" when wallet is locked
- [RPC] getinfo/getstakingstatus - Show disabled / inactive when wallet is locked