### PR TITLE
Remove time-based version disconnect

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5867,38 +5867,11 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vRecv >> LIMITED_STRING(pfrom->strSubVer, 256);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
         }
-        std::time_t time = std::time(0);  // t is an integer type
-        if (time >= 1572220800) { //Monday, Oct 28 at midnight UTC - 1572220800
-            if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/") {
+        if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/" || pfrom->strSubVer == "/DAPScoin:1.0.0/" || pfrom->strSubVer == "/DAPScoin:1.0.1/" || pfrom->strSubVer == "/DAPS:1.0.1.3/" || pfrom->strSubVer == "/DAPS:1.0.2/") {
                 // disconnect from peers other than these sub versions
                 LogPrintf("partner %s using obsolete version %s; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
                 pfrom->fDisconnect = true;
                 return false;
-            }
-        }
-        if (time >= 1572307200) { //Tuesday, Oct 29 at midnight UTC - 1572307200
-            if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/" || pfrom->strSubVer == "/DAPScoin:1.0.0/") {
-                // disconnect from peers other than these sub versions
-                LogPrintf("partner %s using obsolete version %s; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
-                pfrom->fDisconnect = true;
-                return false;
-            }
-        }
-        if (time >= 1572393600) { //Wed, Oct 30 at midnight UTC - 1572393600
-            if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/" || pfrom->strSubVer == "/DAPScoin:1.0.0/" || pfrom->strSubVer == "/DAPScoin:1.0.1/" || pfrom->strSubVer == "/DAPS:1.0.1.3/") {
-                // disconnect from peers other than these sub versions
-                LogPrintf("partner %s using obsolete version %s; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
-                pfrom->fDisconnect = true;
-                return false;
-            }
-        }
-        if (time >= 1572480000) { //Thursday, Oct 31 at midnight UTC - 1572480000
-            if (pfrom->strSubVer == "/DAPScoin:0.27.5.1/" || pfrom->strSubVer == "/DAPScoin:1.0.0/" || pfrom->strSubVer == "/DAPScoin:1.0.1/" || pfrom->strSubVer == "/DAPS:1.0.1.3/" || pfrom->strSubVer == "/DAPS:1.0.2/") {
-                // disconnect from peers other than these sub versions
-                LogPrintf("partner %s using obsolete version %s; disconnecting\n", pfrom->addr.ToString().c_str(), pfrom->strSubVer.c_str());
-                pfrom->fDisconnect = true;
-                return false;
-            }
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;


### PR DESCRIPTION
- Remove time-based version disconnect

Now that the time has passed for the tiered disconnect, we can make it a blanket ban of older versions, regardless of timestamp.