### PR TITLE
DAPS-1258 Linux binaries in the publicly downloadable ZIPs should already be executable

### DIFF
--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -121,7 +121,8 @@ RUN cd /BUILD/ && \
     #files only
     find ./ -type f | \
     #zip
-    zip -j@ $DESTDIR$BUILD_TARGET-v$VERSION.zip -x *test*
+    zip -j@ $DESTDIR$BUILD_TARGET-v$VERSION.zip -x *test* -x *dapscoin-poa-minerd* && \
+	if [ -f bin/dapscoin-poa-minerd* ]; then zip -j dapscoin-poa-$BUILD_TARGET.zip bin/dapscoin-poa-minerd*; fi
 
 RUN mkdir -p /codefresh/volume/out/bin/ && \
     cp -r /daps/bin/* /codefresh/volume/out/bin/ && \

--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -120,10 +120,8 @@ RUN cd /BUILD/ && \
     mkdir -p $DESTDIR && \
     #files only
     find ./ -type f | \
-    #flatten
-    tar pcvf - --transform 's/.*\///g' --files-from=/dev/stdin | \
-    #compress
-    xz -9 - > $DESTDIR$BUILD_TARGET-v$VERSION.tar.xz
+    #zip
+    zip -@ $DESTDIR$BUILD_TARGET-v$VERSION.zip
 
 RUN mkdir -p /codefresh/volume/out/bin/ && \
     cp -r /daps/bin/* /codefresh/volume/out/bin/ && \

--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -122,7 +122,7 @@ RUN cd /BUILD/ && \
     find ./ -type f | \
     #zip
     zip -j@ $DESTDIR$BUILD_TARGET-v$VERSION.zip -x *test* -x *dapscoin-poa-minerd* && \
-	if [ -f bin/dapscoin-poa-minerd* ]; then zip -j dapscoin-poa-$BUILD_TARGET.zip bin/dapscoin-poa-minerd*; fi
+	if [ -f bin/dapscoin-poa-minerd* ]; then zip -j dapscoin-poa-minerd-$BUILD_TARGET.zip bin/dapscoin-poa-minerd*; fi
 
 RUN mkdir -p /codefresh/volume/out/bin/ && \
     cp -r /daps/bin/* /codefresh/volume/out/bin/ && \

--- a/boot/cf/compile.Dockerfile
+++ b/boot/cf/compile.Dockerfile
@@ -121,7 +121,7 @@ RUN cd /BUILD/ && \
     #files only
     find ./ -type f | \
     #zip
-    zip -@ $DESTDIR$BUILD_TARGET-v$VERSION.zip
+    zip -j@ $DESTDIR$BUILD_TARGET-v$VERSION.zip -x *test*
 
 RUN mkdir -p /codefresh/volume/out/bin/ && \
     cp -r /daps/bin/* /codefresh/volume/out/bin/ && \

--- a/boot/cf/oslibs.Dockerfile
+++ b/boot/cf/oslibs.Dockerfile
@@ -6,7 +6,7 @@ ENV SRC_IMG=${SRC_PATH}:${OS_VERSION}
 
 #INSTALL COMMON ESSENTIAL
 RUN apt-get update && \
-    apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl wget nsis libevent-dev python-setuptools patch -y --fix-missing
+    apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl wget nsis libevent-dev python-setuptools patch zip -y --fix-missing
 
 #INSTALL POA MINER DEPENDENCIES
 RUN apt-get install libcurl4-openssl-dev libjansson-dev -y --fix-missing


### PR DESCRIPTION
- Add zip package to OSLibs
- Use .zip instead of tar.xz
- Exclude PoA Miner, packaged by itself in another .zip
- Adjust filename to dapscoin-poa-minerd-$BUILD_TARGET.zip