### PR TITLE
DAPS-1248 From PIVX: Remove (explicitely) unused tx comparator [Potential fixes for: DAPS-1037/DAPS-1181]

### DIFF
--- a/src/obfuscation.cpp
+++ b/src/obfuscation.cpp
@@ -1118,11 +1118,6 @@ void CObfuscationPool::SendObfuscationDenominate(std::vector<CTxIn>& vin, std::v
         return;
     }
 
-    if (txCollateral == CMutableTransaction()) {
-        LogPrintf("CObfuscationPool:SendObfuscationDenominate() - Obfuscation collateral not set");
-        return;
-    }
-
     // lock the funds we're going to use
     BOOST_FOREACH (CTxIn in, txCollateral.vin)
         lockedCoins.push_back(in);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -436,16 +436,6 @@ struct CMutableTransaction
     uint256 GetHash() const;
 
     std::string ToString() const;
-
-    friend bool operator==(const CMutableTransaction& a, const CMutableTransaction& b)
-    {
-        return a.GetHash() == b.GetHash();
-    }
-
-    friend bool operator!=(const CMutableTransaction& a, const CMutableTransaction& b)
-    {
-        return !(a == b);
-    }
 };
 
 struct CTransactionSignature


### PR DESCRIPTION
We remove the '==' and '!=' operators from CMutableTransaction.
These comparators are never explicitely used in our code.

Potential fixes for DAPS-1037/DAPS-1181

From https://github.com/PIVX-Project/PIVX/pull/939

Potentially fixes Orphaned transaction time mismatch that we are experiencing