### PR TITLE
DAPS 1160 : RPC: Break the 'getstakingstatus' into two parts: Staking Mode can either be enabled|disabled, and Staking Status could be inactive|active|waiting|idle|delayed

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -117,10 +117,16 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
         nStaking = true;
     if (pwalletMain->IsLocked()) {
         obj.push_back(Pair("staking mode", ("disabled")));
-        obj.push_back(Pair("staking status", ("inactive")));
+        obj.push_back(Pair("staking status", ("inactive (wallet locked)")));
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-        if (!masternodeSync.IsSynced()) {
+        if (!chainActive.Tip()->nTime > 1471482000) {
+            obj.push_back(Pair("staking status", ("inactive (invalid time)")));
+        } else if (vNodes.empty()) {
+            obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!pwalletMain->MintableCoins()) {
+            obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
+        } else if (!masternodeSync.IsSynced()) {
             obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
@@ -515,10 +521,16 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         nStaking = true;
     if (pwalletMain->IsLocked()) {
         obj.push_back(Pair("staking mode", ("disabled")));
-        obj.push_back(Pair("staking status", ("inactive")));
+        obj.push_back(Pair("staking status", ("inactive (wallet locked)")));
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-        if (!masternodeSync.IsSynced()) {
+        if (!chainActive.Tip()->nTime > 1471482000) {
+            obj.push_back(Pair("staking status", ("inactive (invalid time)")));
+        } else if (vNodes.empty()) {
+            obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!pwalletMain->MintableCoins()) {
+            obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
+        } else if (!masternodeSync.IsSynced()) {
             obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -120,9 +120,7 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
         obj.push_back(Pair("staking status", ("inactive (wallet locked)")));
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-        if (!chainActive.Tip()->nTime > 1471482000) {
-            obj.push_back(Pair("staking status", ("inactive (invalid time)")));
-        } else if (vNodes.empty()) {
+        if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
@@ -485,7 +483,6 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
             "Returns an object containing various staking information.\n"
             "\nResult:\n"
             "{\n"
-            "  \"validtime\": true|false,           (boolean) if the chain tip is within staking phases\n"
             "  \"haveconnections\": true|false,     (boolean) if network connections are present\n"
             "  \"walletunlocked\": true|false,      (boolean) if the wallet is unlocked\n"
             "  \"mintablecoins\": true|false,       (boolean) if the wallet has mintable coins\n"
@@ -505,7 +502,6 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
 
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("validtime", chainActive.Tip()->nTime > 1471482000));
     obj.push_back(Pair("haveconnections", !vNodes.empty()));
     if (pwalletMain) {
         obj.push_back(Pair("walletunlocked", !pwalletMain->IsLocked()));
@@ -524,9 +520,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("staking status", ("inactive (wallet locked)")));
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
-        if (!chainActive.Tip()->nTime > 1471482000) {
-            obj.push_back(Pair("staking status", ("inactive (invalid time)")));
-        } else if (vNodes.empty()) {
+        if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -122,12 +122,12 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
+            obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
         } else if (!masternodeSync.IsSynced()) {
             obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
-        } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
-            obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else {
             obj.push_back(Pair("staking status", (nStaking ? "active (attempting to mint a block)" : "idle (waiting for next round)")));
         }
@@ -522,12 +522,12 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
+            obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
         } else if (!masternodeSync.IsSynced()) {
             obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
-        } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
-            obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else {
             obj.push_back(Pair("staking status", (nStaking ? "active (attempting to mint a block)" : "idle (waiting for next round)")));
         }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -121,7 +121,7 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (!masternodeSync.IsSynced()) {
-            obj.push_back(Pair("staking status", ("syncing masternode list")));
+            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else {
@@ -519,7 +519,7 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
     } else {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (!masternodeSync.IsSynced()) {
-            obj.push_back(Pair("staking status", ("syncing masternode list")));
+            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else {


### PR DESCRIPTION
This is the follow up to today's discussion on the various inactive states.

![image](https://user-images.githubusercontent.com/2319897/68727875-a1235480-0593-11ea-996f-eb5af808288f.png)
