### PR TITLE
DAPS-905 The Create Passphrase confirmation dialog does not look like typical DAPS designs

### DIFF
--- a/src/qt/res/css/Dark.css
+++ b/src/qt/res/css/Dark.css
@@ -26,6 +26,7 @@ QComboBox:disabled,
   border: 1px solid rgb(51, 54, 54);
 }*/
 QDialog {
+  min-width: 500px;
   background: qlineargradient(
     x1: 0 y1: 0,
     x2: 1 y2: 1,

--- a/src/qt/res/css/Light.css
+++ b/src/qt/res/css/Light.css
@@ -47,6 +47,7 @@ QComboBox:disabled,
 }
 
 QDialog {
+  min-width: 500px;
   background-color: white;
 }
 


### PR DESCRIPTION
- Set min-width of QDialogs to 500px

(Example in https://arcadia2.atlassian.net/browse/DAPS-905 is 386px)