### PR TITLE
DAPS-1325 QT: Staking indicator stays positive (Green dot with Enabling staking... subtitle) If wallet lock by failed reveal mnemonic

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -1092,7 +1092,7 @@ void BitcoinGUI::setStakingStatus()
         stkStatus = pwalletMain->ReadStakingStatus();
     }
 
-    if (!stkStatus || pwalletMain->stakingMode == StakingMode::STOPPED) {
+    if (!stkStatus || pwalletMain->stakingMode == StakingMode::STOPPED || pwalletMain->IsLocked()) {
         stakingState->setText(tr("Staking Disabled"));
         stakingState->setToolTip("Staking Disabled");
         stakingAction->setIcon(QIcon(":/icons/staking_inactive"));


### PR DESCRIPTION
- Show Staking Disabled when locked