### PR TITLE
DAPS-1160 [Fix] Move "inactive (syncing masternode list)" up the list to match UI

### DIFF
--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -122,12 +122,12 @@ UniValue getinfo(const UniValue &params, bool fHelp) {
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!masternodeSync.IsSynced()) {
+            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
-        } else if (!masternodeSync.IsSynced()) {
-            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else {
             obj.push_back(Pair("staking status", (nStaking ? "active (attempting to mint a block)" : "idle (waiting for next round)")));
         }
@@ -522,12 +522,12 @@ UniValue getstakingstatus(const UniValue& params, bool fHelp)
         obj.push_back(Pair("staking mode", (pwalletMain->ReadStakingStatus() ? "enabled" : "disabled")));
         if (vNodes.empty()) {
             obj.push_back(Pair("staking status", ("inactive (no peer connections)")));
+        } else if (!masternodeSync.IsSynced()) {
+            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else if (!pwalletMain->MintableCoins() && pwalletMain->stakingMode == StakingMode::STAKING_WITH_CONSOLIDATION) {
             obj.push_back(Pair("staking status", ("delayed (waiting for 100 blocks)")));
         } else if (!pwalletMain->MintableCoins()) {
             obj.push_back(Pair("staking status", ("inactive (no mintable coins)")));
-        } else if (!masternodeSync.IsSynced()) {
-            obj.push_back(Pair("staking status", ("inactive (syncing masternode list)")));
         } else {
             obj.push_back(Pair("staking status", (nStaking ? "active (attempting to mint a block)" : "idle (waiting for next round)")));
         }


### PR DESCRIPTION
Move "inactive (syncing masternode list)" up the list to match UI