### PR TITLE
DAPS-1248 from PIVX: [Wallet] Fix double locked coin when wallet and MN are on same machine

### DIFF
--- a/src/wallet.h
+++ b/src/wallet.h
@@ -1307,7 +1307,7 @@ public:
             }
 
             // Add masternode collaterals which are handled likc locked coins
-            if (fMasterNode && pwallet->getCTxOutValue(*this, vout[i]) == 1000000 * COIN) {
+             else if (fMasterNode && pwallet->getCTxOutValue(*this, vout[i]) == 1000000 * COIN) {
                 nCredit += pwallet->GetCredit(*this, txout, ISMINE_SPENDABLE);
             }
 


### PR DESCRIPTION
- Fix double locked coin when wallet and MN are on the same machine; it is an edge case, but should still be fixed

Related to https://github.com/PIVX-Project/PIVX/issues/654