### PR TITLE
DAPS-1354 Qt > History: Show amounts as "Locked; Hidden" if wallet is locked

### DIFF
--- a/src/qt/historypage.cpp
+++ b/src/qt/historypage.cpp
@@ -207,7 +207,8 @@ void HistoryPage::updateTableData()
 
 void HistoryPage::updateTableData(CWallet* wallet)
 {
-	if (!wallet) return;
+    if (!wallet) return;
+    if (!wallet || wallet->IsLocked()) return;
     TRY_LOCK(cs_main, lockMain);
     if (!lockMain)
         return;


### PR DESCRIPTION
Fix regression

Qt > History: Show amounts as "Locked; Hidden" if wallet is locked