### PR TITLE
DAPS-1165 Turn off, and disable the auto-reconsolidation-while-staking feature …

### DIFF
--- a/src/qt/optionspage.cpp
+++ b/src/qt/optionspage.cpp
@@ -112,9 +112,14 @@ OptionsPage::OptionsPage(QWidget* parent) : QDialog(parent, Qt::WindowSystemMenu
     connect(timerStakingToggleSync, SIGNAL(timeout()), this, SLOT(setStakingToggle()));
     timerStakingToggleSync->start(10000);
 
-    if (pwalletMain) {
-        bool isConsolidatedOn = pwalletMain->IsAutoConsolidateOn();
-        ui->addNewFunds->setChecked(isConsolidatedOn);
+    if (!pwalletMain->IsMasternodeController()) {
+        if (pwalletMain) {
+            bool isConsolidatedOn = pwalletMain->IsAutoConsolidateOn();
+            ui->addNewFunds->setChecked(isConsolidatedOn);
+        }
+    } else {
+        ui->addNewFunds->setChecked(false);
+        ui->addNewFunds->setEnabled(false);
     }
     connect(ui->addNewFunds, SIGNAL(stateChanged(int)), this, SLOT(setAutoConsolidate(int)));
 }


### PR DESCRIPTION
…if being used as a masternode controller

We also set ui->addNewFunds->setChecked(false); even though it should be disabled due to it possibly being enabled on the previous version. We want to disable the function as well as the check box.

![image](https://user-images.githubusercontent.com/2319897/69894864-a69ecf80-12f3-11ea-8107-d4a065577c29.png)
